### PR TITLE
Do not output colorized config when environment does not support it

### DIFF
--- a/cli/apiconfig.go
+++ b/cli/apiconfig.go
@@ -68,8 +68,6 @@ func (a APIConfig) Save() error {
 
 // Return colorized string of configuration in JSON or YAML
 func (a APIConfig) GetPrettyDisplay(outFormat string) ([]byte, error) {
-	var prettyConfig []byte
-
 	// marshal
 	if outFormat == "auto" {
 		outFormat = "json"
@@ -79,13 +77,17 @@ func (a APIConfig) GetPrettyDisplay(outFormat string) ([]byte, error) {
 		return nil, errors.New("unable to render configuration")
 	}
 
+	if !useColor {
+		return marshalled, nil
+	}
+
 	// colorize
-	prettyConfig, err = Highlight(outFormat, marshalled)
+	marshalled, err = Highlight(outFormat, marshalled)
 	if err != nil {
 		return nil, errors.New("unable to colorize output")
 	}
 
-	return prettyConfig, nil
+	return marshalled, nil
 }
 
 type apiConfigs map[string]*APIConfig

--- a/cli/apiconfig_test.go
+++ b/cli/apiconfig_test.go
@@ -15,13 +15,23 @@ func TestAPIContentTypes(t *testing.T) {
 }
 
 func TestAPIShow(t *testing.T) {
-	reset(false)
-	configs["test"] = &APIConfig{
-		name: "test",
-		Base: "https://api.example.com",
+	for tn, tc := range map[string]struct {
+		color bool
+		want  string
+	}{
+		"no color": {false, "{\n  \"base\": \"https://api.example.com\"\n}\n"},
+		"color":    {true, "\x1b[38;5;247m{\x1b[0m\n  \x1b[38;5;74m\"base\"\x1b[0m\x1b[38;5;247m:\x1b[0m \x1b[38;5;150m\"https://api.example.com\"\x1b[0m\n\x1b[38;5;247m}\x1b[0m\n"},
+	} {
+		t.Run(tn, func(t *testing.T) {
+			reset(tc.color)
+			configs["test"] = &APIConfig{
+				name: "test",
+				Base: "https://api.example.com",
+			}
+			captured := runNoReset("api show test")
+			assert.Equal(t, captured, tc.want)
+		})
 	}
-	captured := runNoReset("api show test")
-	assert.Equal(t, captured, "\x1b[38;5;247m{\x1b[0m\n  \x1b[38;5;74m\"base\"\x1b[0m\x1b[38;5;247m:\x1b[0m \x1b[38;5;150m\"https://api.example.com\"\x1b[0m\n\x1b[38;5;247m}\x1b[0m\n")
 }
 
 func TestAPIClearCache(t *testing.T) {


### PR DESCRIPTION
Currently, regardless of the `COLOR` / `NOCOLOR` environment settings, the output of `restish api show $API` is output in color. This is quite inconvenient when piping the output to other programs which are unable to process the ANSI color codes. In my case, this specifically breaks piping the output into `jq`.

For example, with the current release:

```console
$ restish api show default | jq '.profiles.default.headers | keys[]'
jq: parse error: Invalid numeric literal at line 1, column 2

```

With this fix included:

```console
$ restish api show mc | jq '.profiles.default.headers | keys[]'
"authorization"

```