### PR TITLE
fix: send scopes on refresh token requests

### DIFF
--- a/oauth/authcode.go
+++ b/oauth/authcode.go
@@ -373,6 +373,7 @@ func (h *AuthorizationCodeHandler) OnRequest(request *http.Request, key string, 
 		refreshSource := RefreshTokenSource{
 			ClientID:       params["client_id"],
 			TokenURL:       params["token_url"],
+			Scopes:         strings.Split(params["scopes"], ","),
 			EndpointParams: &endpointParams,
 			RefreshToken:   cli.Cache.GetString(refreshKey),
 			TokenSource:    source,

--- a/oauth/refresh.go
+++ b/oauth/refresh.go
@@ -3,6 +3,7 @@ package oauth
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/danielgtaylor/restish/cli"
 	"golang.org/x/oauth2"
@@ -16,6 +17,9 @@ type RefreshTokenSource struct {
 
 	// TokenURL is used to fetch new tokens
 	TokenURL string
+
+	// Scopes to request when refreshing the token
+	Scopes []string
 
 	// EndpointParams are extra URL query parameters to include in the request
 	EndpointParams *url.Values
@@ -35,7 +39,7 @@ type RefreshTokenSource struct {
 func (ts *RefreshTokenSource) Token() (*oauth2.Token, error) {
 	if ts.RefreshToken != "" {
 		cli.LogDebug("Trying refresh token to get a new access token")
-		payload := fmt.Sprintf("grant_type=refresh_token&client_id=%s&refresh_token=%s", ts.ClientID, ts.RefreshToken)
+		payload := fmt.Sprintf("grant_type=refresh_token&client_id=%s&refresh_token=%s&scope=%s", ts.ClientID, ts.RefreshToken, strings.Join(ts.Scopes, " "))
 
 		params := ts.EndpointParams.Encode()
 		if len(params) > 0 {

--- a/oauth/refresh.go
+++ b/oauth/refresh.go
@@ -2,6 +2,7 @@ package oauth
 
 import (
 	"net/url"
+	"strings"
 
 	"github.com/danielgtaylor/restish/cli"
 	"golang.org/x/oauth2"
@@ -41,7 +42,7 @@ func (ts *RefreshTokenSource) Token() (*oauth2.Token, error) {
 			"grant_type":    []string{"refresh_token"},
 			"client_id":     []string{ts.ClientID},
 			"refresh_token": []string{ts.RefreshToken},
-			"scope":         ts.Scopes,
+			"scope":         []string{strings.Join(ts.Scopes, " ")},
 		}
 
 		// Copy any endpoint-specific parameters.


### PR DESCRIPTION
This small PR sends the scopes originally requested when fetching an access token to the refresh token endpoint (if one is available). I ran into an issue where Azure Entra refuses the refresh token unless the scopes match the original request. I *believe* this is safe to do as the spec labels this field as optional and other auth systems should either confirm the scopes are equal or ignore it, but could use some help testing.

BTW, the auth package is missing a lot of tests, so I haven't added one here, but eventually it would be nice to get some tests there.