### PR TITLE
feat: add operation-aware conditional security

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -2,7 +2,7 @@
 //
 // The token cache (CachedToken, TokenStore, TokenCache) and the
 // auth-handler interfaces (Handler, Param, AuthContext, Prompter, Logger,
-// ForceCapable) are part of the supported public surface. External tools
+// ForceCapable, RequestBound) are part of the supported public surface. External tools
 // that need to share the restish OAuth token cache, or embed restish in
 // a Go binary and register custom auth handlers, use this package.
 //
@@ -73,6 +73,13 @@ type Handler interface {
 // after a 401 and retry once with fresh auth state.
 type ForceCapable interface {
 	SupportsForce()
+}
+
+// RequestBound marks handlers whose authentication value is bound to the
+// exact method and URI. Restish invokes such handlers again for every
+// transport retry and same-origin redirect instead of replaying a proof.
+type RequestBound interface {
+	SupportsRequestBinding()
 }
 
 // Compile-time check that *TokenCache satisfies TokenStore.

--- a/auth/tokencache.go
+++ b/auth/tokencache.go
@@ -18,10 +18,16 @@ var renameTokenCacheFile = os.Rename
 
 // CachedToken holds a cached OAuth2 access token and optional refresh token.
 type CachedToken struct {
-	AccessToken  string    `cbor:"access_token" json:"access_token"`
-	TokenType    string    `cbor:"token_type,omitempty" json:"token_type,omitempty"`
-	RefreshToken string    `cbor:"refresh_token,omitempty" json:"refresh_token,omitempty"`
-	Expiry       time.Time `cbor:"expiry,omitempty" json:"expiry,omitempty"`
+	AccessToken       string    `cbor:"access_token" json:"access_token"`
+	TokenType         string    `cbor:"token_type,omitempty" json:"token_type,omitempty"`
+	RefreshToken      string    `cbor:"refresh_token,omitempty" json:"refresh_token,omitempty"`
+	Expiry            time.Time `cbor:"expiry,omitempty" json:"expiry,omitempty"`
+	DPoPPrivateKey    []byte    `cbor:"dpop_private_key,omitempty" json:"dpop_private_key,omitempty"`
+	DPoPNonce         string    `cbor:"dpop_nonce,omitempty" json:"dpop_nonce,omitempty"`
+	CredentialSource  string    `cbor:"credential_source,omitempty" json:"credential_source,omitempty"`
+	CredentialRef     string    `cbor:"credential_ref,omitempty" json:"credential_ref,omitempty"`
+	ResourceIndicator string    `cbor:"resource_indicator,omitempty" json:"resource_indicator,omitempty"`
+	Scopes            []string  `cbor:"scopes,omitempty" json:"scopes,omitempty"`
 }
 
 // IsExpired reports whether the token is expired (or will expire within 30s).
@@ -163,6 +169,37 @@ func (c *TokenCache) Refresh(key string, force bool, refresh func(CachedToken) (
 		return nil, false, err
 	}
 	return &refreshed, true, nil
+}
+
+// Resolve serializes provider-backed credential acquisition for key across
+// processes. The resolver receives nil when no entry exists and returns the
+// complete canonical entry that should replace it.
+func (c *TokenCache) Resolve(key string, resolve func(*CachedToken) (CachedToken, error)) (*CachedToken, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	lock, err := fileutil.LockSiblingFile(c.path)
+	if err != nil {
+		return nil, err
+	}
+	defer lock.Close()
+	m, err := c.loadLocked()
+	if err != nil {
+		return nil, err
+	}
+	var current *CachedToken
+	if cached, ok := m[key]; ok {
+		copy := cached
+		current = &copy
+	}
+	next, err := resolve(current)
+	m[key] = next
+	if err := c.saveLocked(m); err != nil {
+		return nil, err
+	}
+	if err != nil {
+		return &next, err
+	}
+	return &next, nil
 }
 
 func (c *TokenCache) load() (map[string]CachedToken, error) {

--- a/docs/design/004-authentication.md
+++ b/docs/design/004-authentication.md
@@ -411,6 +411,12 @@ requests but stops after producing the auth mutations that would be applied.
 The command lives under API management because v2 auth can be credential-specific
 and operation-specific.
 
+An auth resolver needs the final request method, URL, and complete security
+alternative. When inspection does not have that final target, it reports that
+resolver evaluation is deferred until request time instead of invoking the
+plugin, reporting the credential as missing, or claiming the operation is
+callable. Static credential configuration errors still fail inspection.
+
 Default output is human-oriented and shows the computed auth values because the
 user explicitly asked to inspect auth material. Ambient request diagnostics,
 logs, plugin payloads, and config display remain redacted by default.

--- a/docs/design/019-hook-plugins.md
+++ b/docs/design/019-hook-plugins.md
@@ -12,6 +12,7 @@ so they can maintain output state across paginated and event-stream renders.
 
 This model is used for:
 
+- `auth-resolver`
 - `auth`
 - `request-middleware`
 - `response-middleware`
@@ -108,6 +109,34 @@ boundary when the built-in OAuth flows are too small. The plugin can own the
 provider-specific token exchange and return ordinary request updates, while the
 core keeps common OAuth helpers focused on standard client credentials,
 authorization code, and device-code behavior.
+
+### Auth Resolver Hook
+
+The `auth-resolver` hook lets a credential-owning plugin satisfy operation
+security without placeholder credentials in Restish config. Restish consults
+it only after configured credentials fail. It sends one complete OpenAPI
+security alternative (an AND set), the API/profile names, and the final request
+method and URI. The plugin replies only with `handled: true` or `false`.
+
+Restish tries alternatives in document order. Exactly one plugin may claim an
+alternative; multiple claims are an error. Once selected, Restish invokes only
+that plugin's `auth` hook and includes the same requirements, including exact
+scope needs. The resolver cannot change the target, requirement set, or
+profile, and `security: []` never invokes it. Plugins requiring this contract
+declare the `auth.operation_security` feature.
+
+Resolvers should claim only already-available credentials that cover the whole
+alternative. Interactive authorization, refresh, or request signing belongs in
+the selected `auth` hook. This keeps resolution deterministic and prevents a
+resolver from widening authority while Restish is choosing credentials.
+
+Auth inspection does not invoke a resolver without a final request target.
+Instead, it distinguishes statically callable operations from operations whose
+security will be evaluated by a resolver at request time. It must not report
+those operations as missing static credentials or suggest adding a static
+binding as the primary action merely because resolver selection is deferred.
+The diagnostic may retain a generic static-configuration fallback for use when
+the resolver declines.
 
 ### Request Middleware Hook
 

--- a/docs/design/033-openapi-operation-security.md
+++ b/docs/design/033-openapi-operation-security.md
@@ -49,6 +49,8 @@ credential inside that profile according to normalized operation requirements.
   checks.
 - Keep startup command registration offline. Operation security matching must
   use cached operation metadata and local config.
+- Allow a credential-owning auth plugin to satisfy exact operation security
+  requirements without persisting a synthetic credential binding.
 - Keep `x-cli-config` useful as setup guidance without letting it replace
   standard OpenAPI `securitySchemes` and operation `security` policy.
 - Keep the Restish config model generic enough that another loader could produce
@@ -103,6 +105,26 @@ Startup command registration must stay offline. Any security matching must use
 the generated operation cache, local config, and already-loaded plugin metadata.
 It must not contact OAuth issuers, fetch specs, or prompt the user during shell
 startup.
+
+When configured credentials cannot satisfy an operation, Restish may ask
+installed `auth-resolver` plugins about each complete security alternative in
+OpenAPI order. A resolver receives the final rewritten request target and exact
+requirements. It may claim the alternative but cannot edit it. More than one
+claim is rejected as ambiguous. A selected plugin receives the same
+requirements in its `auth` hook. Explicit configured credentials remain higher
+priority, and public `security: []` operations never enter resolver selection.
+Authentication selected through a resolver is request-bound: Restish invokes
+the selected plugin again before each transport retry so proof-of-possession
+headers are never replayed across network attempts.
+
+Inspection remains offline and side-effect free. When no configured credential
+can be inspected and an applicable resolver is installed, `api auth inspect`
+reports resolver evaluation as deferred until the final request method and URL
+are known. It does not claim that the operation is callable, and it does not
+recommend a specific static credential before the resolver is evaluated. It may
+retain a generic `auth add` fallback for a resolver that declines. Configured
+credential errors remain authoritative and are not hidden by deferred resolver
+status.
 
 ## OpenAPI Security Model
 

--- a/docs/design/044-dpop-credential-sources.md
+++ b/docs/design/044-dpop-credential-sources.md
@@ -1,0 +1,132 @@
+# DPoP Credentials And Token Sources
+
+## Status
+
+Accepted for the v2 development line. The design separates proof-capable
+request authentication from provider-specific token acquisition.
+
+## Problem
+
+An RFC 9449 DPoP credential is not a static header. The client must retain one
+asymmetric key, obtain an access token bound to that key, and create a unique
+proof for every protected-resource request. Some authorization servers expose
+ordinary OAuth token and refresh endpoints. Other deployments broker token
+issuance through a local identity service that must authenticate the caller and
+relay a proof to another authorization server.
+
+The existing `auth` and `auth-resolver` plugin hooks let a plugin mutate every
+target request. That makes the plugin, rather than Restish, the owner of the
+target key, token cache, retry behavior, and final request authentication. It
+also prevents `api auth add`, `inspect`, and `logout` from representing the real
+credential lifecycle.
+
+## Decision
+
+Restish owns every configured target DPoP credential:
+
+- the P-256 private key and its persistent cache entry;
+- the current access token, token type, expiry, Resource indicator, and scopes;
+- the `Authorization: DPoP` header and fresh proof on each target request;
+- forced reacquisition after a rejected token;
+- deletion through the existing auth-cache lifecycle.
+
+Provider-specific code may implement the narrow `credential-source` plugin
+hook. A source never receives the DPoP private key and never mutates the target
+request. Token acquisition is a two-message operation:
+
+1. `describe` resolves an opaque source reference to a proof method and URI,
+   Resource indicator, and authorized scopes.
+2. Restish creates a proof for that exact method and URI and sends `issue` with
+   only the opaque reference and signed proof. The source returns an OAuth-like
+   short-lived credential response.
+
+The source response is transported only over the bounded plugin CBOR channel.
+Restish never prints token material. A manifest must explicitly declare the
+`credential-source` hook and the additive `auth.dpop_credential_source` and
+`auth.dpop_operation_scopes` required features.
+
+The built-in auth type is `dpop`. Its required configuration parameters are:
+
+- `source`: the manifest name of one installed credential-source plugin;
+- `reference`: an opaque, non-secret provider reference.
+
+`restish api auth add <api> <credential-id> --source <plugin>
+--reference <reference>` creates the named OpenAPI credential binding. The
+credential ID remains the local binding to an OpenAPI Security Requirement; it
+is not a token or server-side grant identifier.
+
+For every `describe` and `issue` call, Restish sends the exact scopes required
+by the matched OpenAPI operation. Sources may use that request-scoped set to
+select or acquire an offer without persisting scopes in the credential binding.
+
+Restish maps both `type: http`, `scheme: DPoP` and OAuth 2.0/OpenID Connect
+security schemes marked `x-dpop-required: true` to this auth type. The latter
+preserves the provider's OAuth/OIDC discovery metadata while declaring that a
+plain bearer credential is not acceptable.
+
+## Security Invariants
+
+- Only Restish persists the target private key.
+- Plugins receive public metadata and signed proofs, never private key bytes.
+- `describe` output is validated before signing: the proof URI is absolute,
+  contains no user information or fragment, and uses HTTPS except for loopback
+  HTTP development targets.
+- `issue` must return `token_type=DPoP`, a non-empty token, a future expiry, the
+  same Resource indicator, and scopes covering the current operation.
+- Cache identity includes the API, profile, credential binding, source, and
+  reference. A cached entry whose source metadata differs is not reused.
+- Restish sends a token only when the final target has the same origin as its
+  Resource indicator and falls on that indicator's path boundary.
+- Every protected-resource request gets a new proof bound to its actual method,
+  URI without query or fragment, and access-token hash.
+- A Resource Server `DPoP-Nonce` challenge reuses the still-valid token and key
+  but retries once with the nonce bound into a fresh proof.
+- An authorization-server `use_dpop_nonce` challenge is returned by the source
+  as a structured `dpop-nonce` result. Restish retries credential issuance once
+  with the same key and a fresh proof, and persists a nonce returned with a
+  successful credential for the next issuance request.
+- Cross-origin redirects strip both the authorization and DPoP headers.
+  Transport retries and same-origin redirects regenerate the proof for the
+  exact next request instead of replaying it.
+- Token values, proofs, and private keys are treated as secret fields by
+  inspection, plugin diagnostics, and error redaction.
+
+## Compatibility
+
+The new hook and auth type are additive. Operation scopes are an optional wire
+field and plugins that require them declare `auth.dpop_operation_scopes`.
+Existing bearer, OAuth, external-tool, auth hook, and auth-resolver behavior
+remains available. Providers migrate by
+returning a safe source receipt from their authorization workflow and declaring
+`credential-source`; once all of their target APIs use explicit `dpop`
+credential bindings they should stop claiming those target operations through
+`auth-resolver` and stop mutating them through `auth`.
+
+The first implementation does not change a provider's HTTP credential-offer
+contract. A provider adapter may continue redeeming its existing opaque offer
+internally. Standard OAuth DPoP acquisition can later implement the same
+inward token-source contract without a plugin.
+
+## Rejected Alternatives
+
+- **Pass a raw token to `auth add`:** exposes credentials through argv, shell
+  history, process inspection, or agent transcripts and cannot establish key
+  binding safely.
+- **Let the plugin keep signing target requests:** preserves the ownership
+  problem and leaves Restish auth state inaccurate.
+- **Put a provider-specific offer format in Restish core:** couples the CLI to
+  one identity service and is unsuitable for upstream.
+- **Give the plugin the target private key:** collapses the custody boundary and
+  makes provider code capable of impersonating every target request.
+
+## Verification
+
+Behavioral proof must cover:
+
+- P-256 key creation, persistence, and reuse across access-token renewal;
+- RFC 9449 proof claims and raw ES256 JWS encoding;
+- source discovery, two-phase acquisition, and response validation;
+- per-request target signing and forced reacquisition after rejection;
+- cache separation by credential source reference;
+- absence of target private keys and request mutation in the provider plugin;
+- CLI creation and inspection of one explicit DPoP credential binding.

--- a/docs/design/045-conditional-operation-security.md
+++ b/docs/design/045-conditional-operation-security.md
@@ -1,0 +1,45 @@
+# Conditional Operation Security
+
+## Status
+
+Accepted for the v2 development line.
+
+## Problem
+
+OpenAPI security can express alternatives and conjunctions, but it cannot make
+one alternative conditional on the concrete value of a path parameter. Some
+transparent APIs need exactly that behavior. Publishing all sets as ordinary
+alternatives loses the condition, so a client can request too little authority
+and discover the missing requirement only after the server rejects the request.
+
+## Decision
+
+Restish supports the additive operation extension
+`x-restish-security-alternatives`. It is an ordered list of rules:
+
+```yaml
+x-restish-security-alternatives:
+  - when:
+      pathParameter: path
+      prefix: .github/workflows/
+    alternatives: [1]
+```
+
+`alternatives` contains zero-based indexes into that operation's standard
+OpenAPI `security` array. After the concrete request path is known, Restish
+extracts and percent-decodes the named path parameter. The first matching rule
+replaces the candidate list with the indexed alternatives. When no rule matches,
+standard OpenAPI selection is unchanged.
+
+The extension only narrows standard alternatives; it cannot create a scheme,
+scope, or conjunction. Invalid parameter names, empty predicates, repeated
+indexes, and out-of-range indexes fail specification loading. Authority remains
+visible to ordinary OpenAPI tooling and the extension cannot silently widen it.
+
+## Compatibility
+
+The extension is optional. Existing specifications and clients continue to see
+the complete standard OpenAPI security alternatives. Inspection, help, and
+configuration retain the complete static view because no concrete path value
+exists at those stages. Generated commands and generic requests both apply the
+predicate immediately before operation authentication planning.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -143,6 +143,7 @@ were a recurring source of remediation work.
 - [006-spec-discovery-and-loading.md](./006-spec-discovery-and-loading.md) - Secure spec discovery, loader contracts, caching, revalidation, and failure reporting.
 - [007-api-command-generation.md](./007-api-command-generation.md) - Config-backed API registration, OpenAPI-to-command mapping, naming, parameter handling, and compatibility aliases.
 - [033-openapi-operation-security.md](./033-openapi-operation-security.md) - Operation-specific OpenAPI security policy, credential bindings, setup UX, and compatibility rules.
+- [044-dpop-credential-sources.md](./044-dpop-credential-sources.md) - Native RFC 9449 credential custody with provider-neutral token-source plugins.
 - [034-openapi-implementation-contract.md](./034-openapi-implementation-contract.md) - Implementation-grade OpenAPI 3.x behavior matrix for loading, command generation, parameters, servers, schemas, auth, media types, caching, and tests.
 - [008-shorthand-input.md](./008-shorthand-input.md) - Building request bodies from CLI arguments and stdin using shorthand syntax.
 - [029-request-execution-pipeline.md](./029-request-execution-pipeline.md) - End-to-end request planning, execution order, cancellation, transport layering, normalization, filtering, and rendering.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -144,6 +144,7 @@ were a recurring source of remediation work.
 - [007-api-command-generation.md](./007-api-command-generation.md) - Config-backed API registration, OpenAPI-to-command mapping, naming, parameter handling, and compatibility aliases.
 - [033-openapi-operation-security.md](./033-openapi-operation-security.md) - Operation-specific OpenAPI security policy, credential bindings, setup UX, and compatibility rules.
 - [044-dpop-credential-sources.md](./044-dpop-credential-sources.md) - Native RFC 9449 credential custody with provider-neutral token-source plugins.
+- [045-conditional-operation-security.md](./045-conditional-operation-security.md) - Request-path predicates that narrow standard OpenAPI security alternatives at execution time.
 - [034-openapi-implementation-contract.md](./034-openapi-implementation-contract.md) - Implementation-grade OpenAPI 3.x behavior matrix for loading, command generation, parameters, servers, schemas, auth, media types, caching, and tests.
 - [008-shorthand-input.md](./008-shorthand-input.md) - Building request bodies from CLI arguments and stdin using shorthand syntax.
 - [029-request-execution-pipeline.md](./029-request-execution-pipeline.md) - End-to-end request planning, execution order, cancellation, transport layering, normalization, filtering, and rendering.

--- a/internal/auth/dpop.go
+++ b/internal/auth/dpop.go
@@ -1,0 +1,467 @@
+package auth
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"path"
+	"sort"
+	"strings"
+	"time"
+
+	publicauth "github.com/rest-sh/restish/v2/auth"
+)
+
+// DPoPCredentialDescription is the public acquisition metadata supplied by a
+// provider-specific source before Restish creates the token-endpoint proof.
+type DPoPCredentialDescription struct {
+	ProofMethod string
+	ProofURI    string
+	Resource    string
+	Scopes      []string
+}
+
+// DPoPIssuedCredential is the short-lived credential returned after the
+// source verifies Restish's proof.
+type DPoPIssuedCredential struct {
+	AccessToken string
+	TokenType   string
+	ExpiresAt   time.Time
+	Resource    string
+	Scopes      []string
+	Nonce       string
+}
+
+// DPoPNonceChallenge is returned by a credential source when its authorization
+// server requires a fresh proof containing the supplied opaque nonce.
+type DPoPNonceChallenge struct {
+	Nonce string
+}
+
+func (e *DPoPNonceChallenge) Error() string { return "authorization server requires a DPoP nonce" }
+
+// DPoPCredentialSource is the inward port used by the native DPoP handler.
+// Provider adapters never receive or persist the target private key.
+type DPoPCredentialSource interface {
+	Describe(ctx context.Context, apiName, profileName, sourceName, reference string, scopes []string) (DPoPCredentialDescription, error)
+	Issue(ctx context.Context, apiName, profileName, sourceName, reference, proof string, scopes []string) (DPoPIssuedCredential, error)
+}
+
+type resolvingTokenStore interface {
+	publicauth.TokenStore
+	Resolve(string, func(*publicauth.CachedToken) (publicauth.CachedToken, error)) (*publicauth.CachedToken, error)
+}
+
+// DPoP owns an RFC 9449 key, proof generation, and provider-backed token
+// lifecycle for one configured credential binding.
+type DPoP struct {
+	Source DPoPCredentialSource
+	Now    func() time.Time
+	Random io.Reader
+}
+
+type dpopNonceContextKey struct{}
+
+// SetDPoPNonce attaches a Resource Server nonce to the retry request without
+// exposing it as an outbound implementation header.
+func SetDPoPNonce(req *http.Request, nonce string) {
+	if req == nil || nonce == "" {
+		return
+	}
+	*req = *req.WithContext(context.WithValue(req.Context(), dpopNonceContextKey{}, nonce))
+}
+
+func (h *DPoP) Parameters() []publicauth.Param {
+	return []publicauth.Param{
+		{Name: "source", Description: "Credential-source plugin name", Required: true},
+		{Name: "reference", Description: "Opaque credential-source reference", Required: true},
+	}
+}
+
+func (h *DPoP) SupportsForce() {}
+
+func (h *DPoP) SupportsRequestBinding() {}
+
+func (h *DPoP) Authenticate(ctx context.Context, req *http.Request, ac publicauth.AuthContext) error {
+	if h.Source == nil {
+		return errors.New("dpop: credential source is unavailable")
+	}
+	store, ok := ac.TokenStore.(resolvingTokenStore)
+	if !ok {
+		return errors.New("dpop: token store does not support serialized credential acquisition")
+	}
+	if ac.CacheKey == "" {
+		return errors.New("dpop: cache key is required")
+	}
+	sourceName := strings.TrimSpace(ac.Params["source"])
+	reference := strings.TrimSpace(ac.Params["reference"])
+	if sourceName == "" || reference == "" {
+		return errors.New("dpop: source and reference are required")
+	}
+	requiredScopes := splitScopes(ac.Params["scopes"])
+	nonce, _ := req.Context().Value(dpopNonceContextKey{}).(string)
+	token, err := store.Resolve(ac.CacheKey, func(current *publicauth.CachedToken) (publicauth.CachedToken, error) {
+		if (!ac.Force || nonce != "") && reusableDPoPToken(current, sourceName, reference, requiredScopes, h.now()) {
+			return *current, nil
+		}
+		return h.acquire(ctx, ac, current, sourceName, reference, requiredScopes)
+	})
+	if err != nil {
+		return err
+	}
+	privateKey, err := parseDPoPPrivateKey(token.DPoPPrivateKey)
+	if err != nil {
+		return fmt.Errorf("dpop: load cached private key: %w", err)
+	}
+	if !dpopResourceCoversRequest(token.ResourceIndicator, req.URL) {
+		return fmt.Errorf("dpop: credential Resource %q does not cover request target %q", token.ResourceIndicator, req.URL.String())
+	}
+	proof, err := h.signProof(privateKey, req.Method, req.URL.String(), token.AccessToken, nonce)
+	if err != nil {
+		return fmt.Errorf("dpop: sign protected-resource proof: %w", err)
+	}
+	req.Header.Set("Authorization", "DPoP "+token.AccessToken)
+	req.Header.Set("DPoP", proof)
+	return nil
+}
+
+func (h *DPoP) acquire(
+	ctx context.Context,
+	ac publicauth.AuthContext,
+	current *publicauth.CachedToken,
+	sourceName string,
+	reference string,
+	requiredScopes []string,
+) (publicauth.CachedToken, error) {
+	privateKey, encodedKey, err := h.resolvePrivateKey(current, sourceName, reference)
+	if err != nil {
+		return publicauth.CachedToken{}, fmt.Errorf("dpop: prepare private key: %w", err)
+	}
+	base := publicauth.CachedToken{
+		TokenType:        "DPoP",
+		DPoPPrivateKey:   encodedKey,
+		CredentialSource: sourceName,
+		CredentialRef:    reference,
+	}
+	nonce := reusableCredentialNonce(current, sourceName, reference)
+	base.DPoPNonce = nonce
+	description, err := h.Source.Describe(ctx, ac.APIName, ac.ProfileName, sourceName, reference, requiredScopes)
+	if err != nil {
+		return base, fmt.Errorf("dpop credential source %q describe: %w", sourceName, err)
+	}
+	if err := validateDPoPDescription(description, requiredScopes); err != nil {
+		return base, fmt.Errorf("dpop credential source %q: %w", sourceName, err)
+	}
+	base.ResourceIndicator = description.Resource
+	base.Scopes = append([]string(nil), description.Scopes...)
+	proof, err := h.signProof(privateKey, description.ProofMethod, description.ProofURI, "", nonce)
+	if err != nil {
+		return base, fmt.Errorf("dpop: sign credential proof: %w", err)
+	}
+	issued, err := h.Source.Issue(ctx, ac.APIName, ac.ProfileName, sourceName, reference, proof, requiredScopes)
+	if err != nil {
+		var challenge *DPoPNonceChallenge
+		if !errors.As(err, &challenge) {
+			return base, fmt.Errorf("dpop credential source %q issue: %w", sourceName, err)
+		}
+		if err := validateDPoPNonce(challenge.Nonce); err != nil {
+			return base, fmt.Errorf("dpop credential source %q returned an invalid challenge: %w", sourceName, err)
+		}
+		nonce = challenge.Nonce
+		base.DPoPNonce = nonce
+		proof, err = h.signProof(privateKey, description.ProofMethod, description.ProofURI, "", nonce)
+		if err != nil {
+			return base, fmt.Errorf("dpop: sign nonce-bound credential proof: %w", err)
+		}
+		issued, err = h.Source.Issue(ctx, ac.APIName, ac.ProfileName, sourceName, reference, proof, requiredScopes)
+		if err != nil {
+			var nextChallenge *DPoPNonceChallenge
+			if errors.As(err, &nextChallenge) && validateDPoPNonce(nextChallenge.Nonce) == nil {
+				base.DPoPNonce = nextChallenge.Nonce
+			}
+			return base, fmt.Errorf("dpop credential source %q issue after nonce challenge: %w", sourceName, err)
+		}
+	}
+	if err := validateIssuedDPoPCredential(issued, description, requiredScopes, h.now()); err != nil {
+		return base, fmt.Errorf("dpop credential source %q: %w", sourceName, err)
+	}
+	if issued.Nonce != "" {
+		if err := validateDPoPNonce(issued.Nonce); err != nil {
+			return base, fmt.Errorf("dpop credential source %q returned an invalid next nonce: %w", sourceName, err)
+		}
+		nonce = issued.Nonce
+	}
+	return publicauth.CachedToken{
+		AccessToken:       issued.AccessToken,
+		TokenType:         issued.TokenType,
+		Expiry:            issued.ExpiresAt,
+		DPoPPrivateKey:    encodedKey,
+		DPoPNonce:         nonce,
+		CredentialSource:  sourceName,
+		CredentialRef:     reference,
+		ResourceIndicator: issued.Resource,
+		Scopes:            append([]string(nil), issued.Scopes...),
+	}, nil
+}
+
+func reusableCredentialNonce(current *publicauth.CachedToken, sourceName, reference string) string {
+	if current == nil || current.CredentialSource != sourceName || current.CredentialRef != reference || len(current.DPoPPrivateKey) == 0 {
+		return ""
+	}
+	return current.DPoPNonce
+}
+
+func validateDPoPNonce(value string) error {
+	if value == "" || len(value) > 4096 {
+		return errors.New("nonce must contain between 1 and 4096 characters")
+	}
+	for _, char := range []byte(value) {
+		if char != 0x21 && (char < 0x23 || char > 0x5b) && (char < 0x5d || char > 0x7e) {
+			return errors.New("nonce contains a character outside the RFC 9449 syntax")
+		}
+	}
+	return nil
+}
+
+func (h *DPoP) resolvePrivateKey(current *publicauth.CachedToken, sourceName, reference string) (*ecdsa.PrivateKey, []byte, error) {
+	if current != nil && current.CredentialSource == sourceName && current.CredentialRef == reference && len(current.DPoPPrivateKey) > 0 {
+		key, err := parseDPoPPrivateKey(current.DPoPPrivateKey)
+		return key, append([]byte(nil), current.DPoPPrivateKey...), err
+	}
+	key, err := ecdsa.GenerateKey(elliptic.P256(), h.random())
+	if err != nil {
+		return nil, nil, err
+	}
+	encoded, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return nil, nil, err
+	}
+	return key, encoded, nil
+}
+
+func (h *DPoP) signProof(key *ecdsa.PrivateKey, method, rawURI, accessToken, nonce string) (string, error) {
+	htu, err := normalizedDPoPURI(rawURI)
+	if err != nil {
+		return "", err
+	}
+	method = strings.ToUpper(strings.TrimSpace(method))
+	if method == "" {
+		return "", errors.New("proof method is required")
+	}
+	jtiBytes := make([]byte, 16)
+	if _, err := io.ReadFull(h.random(), jtiBytes); err != nil {
+		return "", err
+	}
+	size := (key.Curve.Params().BitSize + 7) / 8
+	header := map[string]any{
+		"typ": "dpop+jwt",
+		"alg": "ES256",
+		"jwk": map[string]string{
+			"kty": "EC",
+			"crv": "P-256",
+			"x":   base64.RawURLEncoding.EncodeToString(key.PublicKey.X.FillBytes(make([]byte, size))),
+			"y":   base64.RawURLEncoding.EncodeToString(key.PublicKey.Y.FillBytes(make([]byte, size))),
+		},
+	}
+	payload := map[string]any{
+		"jti": base64.RawURLEncoding.EncodeToString(jtiBytes),
+		"htm": method,
+		"htu": htu,
+		"iat": h.now().Unix(),
+	}
+	if accessToken != "" {
+		digest := sha256.Sum256([]byte(accessToken))
+		payload["ath"] = base64.RawURLEncoding.EncodeToString(digest[:])
+	}
+	if nonce != "" {
+		payload["nonce"] = nonce
+	}
+	encodedHeader, err := encodeJWTPart(header)
+	if err != nil {
+		return "", err
+	}
+	encodedPayload, err := encodeJWTPart(payload)
+	if err != nil {
+		return "", err
+	}
+	signingInput := encodedHeader + "." + encodedPayload
+	digest := sha256.Sum256([]byte(signingInput))
+	r, s, err := ecdsa.Sign(h.random(), key, digest[:])
+	if err != nil {
+		return "", err
+	}
+	signature := make([]byte, size*2)
+	r.FillBytes(signature[:size])
+	s.FillBytes(signature[size:])
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(signature), nil
+}
+
+func encodeJWTPart(value any) (string, error) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(data), nil
+}
+
+func parseDPoPPrivateKey(encoded []byte) (*ecdsa.PrivateKey, error) {
+	parsed, err := x509.ParsePKCS8PrivateKey(encoded)
+	if err != nil {
+		return nil, err
+	}
+	key, ok := parsed.(*ecdsa.PrivateKey)
+	if !ok || key.Curve != elliptic.P256() {
+		return nil, errors.New("cached key is not an ES256 private key")
+	}
+	return key, nil
+}
+
+func normalizedDPoPURI(rawURI string) (string, error) {
+	u, err := url.Parse(rawURI)
+	if err != nil || !u.IsAbs() || u.Host == "" {
+		return "", fmt.Errorf("proof URI %q must be absolute", rawURI)
+	}
+	if u.User != nil || u.Fragment != "" {
+		return "", fmt.Errorf("proof URI %q must not contain user information or a fragment", rawURI)
+	}
+	if u.Scheme != "https" && !(u.Scheme == "http" && isLoopbackDPoPHost(u.Hostname())) {
+		return "", fmt.Errorf("proof URI %q must use HTTPS unless it is loopback HTTP", rawURI)
+	}
+	u.RawQuery = ""
+	u.ForceQuery = false
+	return u.String(), nil
+}
+
+func isLoopbackDPoPHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func dpopResourceCoversRequest(resource string, target *url.URL) bool {
+	resourceURL, err := url.Parse(resource)
+	if err != nil || target == nil || !sameDPoPOrigin(resourceURL, target) {
+		return false
+	}
+	resourcePath := path.Clean("/" + strings.TrimPrefix(resourceURL.Path, "/"))
+	targetPath := path.Clean("/" + strings.TrimPrefix(target.Path, "/"))
+	if resourcePath == "/" {
+		return true
+	}
+	return targetPath == resourcePath || strings.HasPrefix(targetPath, resourcePath+"/")
+}
+
+func sameDPoPOrigin(left, right *url.URL) bool {
+	return left != nil && right != nil && strings.EqualFold(left.Scheme, right.Scheme) &&
+		strings.EqualFold(left.Hostname(), right.Hostname()) && effectiveDPoPPort(left) == effectiveDPoPPort(right)
+}
+
+func effectiveDPoPPort(value *url.URL) string {
+	if port := value.Port(); port != "" {
+		return port
+	}
+	if strings.EqualFold(value.Scheme, "https") {
+		return "443"
+	}
+	if strings.EqualFold(value.Scheme, "http") {
+		return "80"
+	}
+	return ""
+}
+
+func validateDPoPDescription(description DPoPCredentialDescription, requiredScopes []string) error {
+	if _, err := normalizedDPoPURI(description.ProofURI); err != nil {
+		return err
+	}
+	if strings.TrimSpace(description.ProofMethod) == "" {
+		return errors.New("credential proof method is required")
+	}
+	if _, err := normalizedDPoPURI(description.Resource); err != nil {
+		return fmt.Errorf("invalid Resource indicator: %w", err)
+	}
+	if !scopeSetContains(description.Scopes, requiredScopes) {
+		return errors.New("credential offer does not cover the operation scopes")
+	}
+	return nil
+}
+
+func validateIssuedDPoPCredential(issued DPoPIssuedCredential, description DPoPCredentialDescription, requiredScopes []string, now time.Time) error {
+	if !strings.EqualFold(issued.TokenType, "DPoP") || strings.TrimSpace(issued.AccessToken) == "" {
+		return errors.New("issued credential is not a DPoP access token")
+	}
+	if !issued.ExpiresAt.After(now) {
+		return errors.New("issued credential is already expired")
+	}
+	if issued.Resource != description.Resource {
+		return errors.New("issued credential Resource indicator differs from its offer")
+	}
+	if !scopeSetContains(issued.Scopes, description.Scopes) || !scopeSetContains(issued.Scopes, requiredScopes) {
+		return errors.New("issued credential does not cover the offered scopes")
+	}
+	return nil
+}
+
+func reusableDPoPToken(token *publicauth.CachedToken, sourceName, reference string, requiredScopes []string, now time.Time) bool {
+	return token != nil && token.AccessToken != "" && strings.EqualFold(token.TokenType, "DPoP") &&
+		token.CredentialSource == sourceName && token.CredentialRef == reference && len(token.DPoPPrivateKey) > 0 &&
+		now.Add(30*time.Second).Before(token.Expiry) && scopeSetContains(token.Scopes, requiredScopes)
+}
+
+func splitScopes(raw string) []string {
+	values := strings.Fields(raw)
+	sort.Strings(values)
+	return slicesCompact(values)
+}
+
+func slicesCompact(values []string) []string {
+	if len(values) < 2 {
+		return values
+	}
+	out := values[:1]
+	for _, value := range values[1:] {
+		if value != out[len(out)-1] {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func scopeSetContains(have, need []string) bool {
+	set := make(map[string]bool, len(have))
+	for _, value := range have {
+		set[value] = true
+	}
+	for _, value := range need {
+		if !set[value] {
+			return false
+		}
+	}
+	return true
+}
+
+func (h *DPoP) now() time.Time {
+	if h.Now != nil {
+		return h.Now()
+	}
+	return time.Now()
+}
+
+func (h *DPoP) random() io.Reader {
+	if h.Random != nil {
+		return h.Random
+	}
+	return rand.Reader
+}

--- a/internal/auth/dpop_test.go
+++ b/internal/auth/dpop_test.go
@@ -1,0 +1,157 @@
+package auth
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	publicauth "github.com/rest-sh/restish/v2/auth"
+)
+
+type dpopCredentialSourceStub struct {
+	describe       DPoPCredentialDescription
+	issue          func(string) (DPoPIssuedCredential, error)
+	describeScopes *[]string
+	issueScopes    *[]string
+}
+
+func (s dpopCredentialSourceStub) Describe(_ context.Context, _, _, _, _ string, scopes []string) (DPoPCredentialDescription, error) {
+	if s.describeScopes != nil {
+		*s.describeScopes = append([]string(nil), scopes...)
+	}
+	return s.describe, nil
+}
+
+func (s dpopCredentialSourceStub) Issue(_ context.Context, _, _, _, _, proof string, scopes []string) (DPoPIssuedCredential, error) {
+	if s.issueScopes != nil {
+		*s.issueScopes = append([]string(nil), scopes...)
+	}
+	return s.issue(proof)
+}
+
+func TestDPoPCredentialAcquisitionRetriesOneNonceChallengeAndRetainsNextNonce(t *testing.T) {
+	now := time.Date(2026, 8, 7, 12, 0, 0, 0, time.UTC)
+	description := DPoPCredentialDescription{
+		ProofMethod: "POST",
+		ProofURI:    "https://issuer.example.com/token",
+		Resource:    "https://api.example.com",
+		Scopes:      []string{"media:read"},
+	}
+	var proofs, describedScopes, issuedScopes []string
+	source := dpopCredentialSourceStub{describe: description, describeScopes: &describedScopes, issueScopes: &issuedScopes}
+	source.issue = func(proof string) (DPoPIssuedCredential, error) {
+		proofs = append(proofs, proof)
+		if len(proofs) == 1 {
+			return DPoPIssuedCredential{}, &DPoPNonceChallenge{Nonce: "challenge-nonce"}
+		}
+		return DPoPIssuedCredential{
+			AccessToken: "token-1", TokenType: "DPoP", ExpiresAt: now.Add(time.Minute),
+			Resource: description.Resource, Scopes: description.Scopes, Nonce: "next-nonce",
+		}, nil
+	}
+	handler := DPoP{Source: source, Now: func() time.Time { return now }}
+	ac := publicauth.AuthContext{APIName: "media", ProfileName: "default", Params: map[string]string{"scopes": "media:read"}}
+
+	token, err := handler.acquire(context.Background(), ac, nil, "realmroot", "resource-ref", []string{"media:read"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(proofs) != 2 {
+		t.Fatalf("issue attempts = %d, want 2", len(proofs))
+	}
+	if strings.Join(describedScopes, " ") != "media:read" || strings.Join(issuedScopes, " ") != "media:read" {
+		t.Fatalf("operation scopes were not forwarded: describe=%v issue=%v", describedScopes, issuedScopes)
+	}
+	firstHeader, firstPayload := decodeDPoPProof(t, proofs[0])
+	secondHeader, secondPayload := decodeDPoPProof(t, proofs[1])
+	if _, exists := firstPayload["nonce"]; exists {
+		t.Fatalf("initial proof unexpectedly contains nonce: %#v", firstPayload)
+	}
+	if secondPayload["nonce"] != "challenge-nonce" {
+		t.Fatalf("retry nonce = %#v", secondPayload["nonce"])
+	}
+	if !equalJSON(firstHeader["jwk"], secondHeader["jwk"]) {
+		t.Fatal("nonce retry changed the DPoP public key")
+	}
+	if firstPayload["jti"] == secondPayload["jti"] {
+		t.Fatal("nonce retry reused the DPoP proof identifier")
+	}
+	if token.DPoPNonce != "next-nonce" {
+		t.Fatalf("cached nonce = %q", token.DPoPNonce)
+	}
+
+	proofs = nil
+	source.issue = func(proof string) (DPoPIssuedCredential, error) {
+		proofs = append(proofs, proof)
+		return DPoPIssuedCredential{
+			AccessToken: "token-2", TokenType: "DPoP", ExpiresAt: now.Add(2 * time.Minute),
+			Resource: description.Resource, Scopes: description.Scopes,
+		}, nil
+	}
+	handler.Source = source
+	renewed, err := handler.acquire(context.Background(), ac, &token, "realmroot", "resource-ref", []string{"media:read"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, renewalPayload := decodeDPoPProof(t, proofs[0])
+	if renewalPayload["nonce"] != "next-nonce" || renewed.DPoPNonce != "next-nonce" {
+		t.Fatalf("renewal nonce payload=%#v cached=%q", renewalPayload["nonce"], renewed.DPoPNonce)
+	}
+}
+
+func TestDPoPCredentialAcquisitionDoesNotLoopOnRepeatedNonceChallenge(t *testing.T) {
+	now := time.Date(2026, 8, 7, 12, 0, 0, 0, time.UTC)
+	attempts := 0
+	source := dpopCredentialSourceStub{
+		describe: DPoPCredentialDescription{ProofMethod: "POST", ProofURI: "https://issuer.example.com/token", Resource: "https://api.example.com"},
+		issue: func(string) (DPoPIssuedCredential, error) {
+			attempts++
+			return DPoPIssuedCredential{}, &DPoPNonceChallenge{Nonce: "nonce"}
+		},
+	}
+	handler := DPoP{Source: source, Now: func() time.Time { return now }}
+	failed, err := handler.acquire(context.Background(), publicauth.AuthContext{}, nil, "realmroot", "resource-ref", nil)
+	if err == nil || attempts != 2 {
+		t.Fatalf("err=%v attempts=%d, want error after 2 attempts", err, attempts)
+	}
+	if failed.DPoPNonce != "nonce" {
+		t.Fatalf("cached challenge nonce = %q", failed.DPoPNonce)
+	}
+}
+
+func decodeDPoPProof(t *testing.T, proof string) (map[string]any, map[string]any) {
+	t.Helper()
+	parts := splitJWT(t, proof)
+	return decodeJWTObject(t, parts[0]), decodeJWTObject(t, parts[1])
+}
+
+func splitJWT(t *testing.T, token string) []string {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("JWT parts = %d", len(parts))
+	}
+	return parts
+}
+
+func decodeJWTObject(t *testing.T, encoded string) map[string]any {
+	t.Helper()
+	raw, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var value map[string]any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		t.Fatal(err)
+	}
+	return value
+}
+
+func equalJSON(left, right any) bool {
+	leftJSON, _ := json.Marshal(left)
+	rightJSON, _ := json.Marshal(right)
+	return string(leftJSON) == string(rightJSON)
+}

--- a/internal/cli/api.go
+++ b/internal/cli/api.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/rest-sh/restish/v2/auth"
 	"github.com/rest-sh/restish/v2/config"
+	authpkg "github.com/rest-sh/restish/v2/internal/auth"
 	"github.com/rest-sh/restish/v2/internal/cache"
 	internalconfig "github.com/rest-sh/restish/v2/internal/config"
 	"github.com/rest-sh/restish/v2/internal/output"
@@ -681,7 +682,7 @@ func (c *CLI) emitGeneratedCommandWarnings(apiName string, apiCfg *config.APICon
 	}
 	set, err := apiSpec.OperationSet(opOpts)
 	if err == nil {
-		for _, issue := range operationSecurityIssues(set.Operations) {
+		for _, issue := range operationSecurityIssuesWithResolver(set.Operations, c.authResolverAvailable(apiName)) {
 			c.warnf("OpenAPI security: %s", issue)
 		}
 	}
@@ -1313,7 +1314,9 @@ func (c *CLI) doDiscoveryRequest(ctx context.Context, method, rawURL string, opt
 	}
 	retryOpts := opts
 	onUnauthorized := retryOpts.OnUnauthorized
+	nonce := resp.Header.Get("DPoP-Nonce")
 	retryOpts.OnRequest = func(req *http.Request) error {
+		authpkg.SetDPoPNonce(req, nonce)
 		if err := onUnauthorized(req); err != nil {
 			return err
 		}

--- a/internal/cli/api_auth.go
+++ b/internal/cli/api_auth.go
@@ -29,14 +29,17 @@ func (c *CLI) newAPIAuthCommand() *cobra.Command {
 			return cmd.Help()
 		},
 	}
-	cmd.AddCommand(&cobra.Command{
+	addCmd := &cobra.Command{
 		Use:     "add <api> <credential-id>",
-		Short:   "Add an empty credential binding to an API profile",
+		Short:   "Add or configure a credential binding on an API profile",
 		Long:    apiAuthAddLong,
-		Example: fmt.Sprintf("  %s api auth add demo PartnerKey", c.commandNameOrDefault()),
+		Example: fmt.Sprintf("  %s api auth add demo PartnerKey\n  %s api auth add demo ResourceDPoP --source identity --reference https://identity.example/resources/123", c.commandNameOrDefault(), c.commandNameOrDefault()),
 		Args:    usageExactArgs(2),
 		RunE:    c.runAPIAuthAdd,
-	})
+	}
+	addCmd.Flags().String("source", "", "credential-source plugin for a DPoP credential")
+	addCmd.Flags().String("reference", "", "opaque credential-source reference for a DPoP credential")
+	cmd.AddCommand(addCmd)
 	cmd.AddCommand(&cobra.Command{
 		Use:     "remove <api> <credential-id>",
 		Short:   "Remove a credential binding from an API profile",
@@ -115,12 +118,26 @@ func (c *CLI) printAPIAuthOverview(cmd *cobra.Command, apiName, profileName stri
 		fmt.Fprintf(c.Stdout, "Generic request auth: %s\n", style.warn("none"))
 	}
 	if hasOps {
-		fmt.Fprintf(c.Stdout, "Callable secured operations: %d/%d\n", coverage.Callable, coverage.Secured)
+		if coverage.SourceEvaluated > 0 || coverage.ResolverEvaluated > 0 {
+			fmt.Fprintf(c.Stdout, "Statically callable secured operations: %d/%d\n", coverage.Callable, coverage.Secured)
+			if coverage.SourceEvaluated > 0 {
+				fmt.Fprintf(c.Stdout, "Credential source evaluated per request: %d/%d secured operations\n", coverage.SourceEvaluated, coverage.Secured)
+			}
+			if coverage.ResolverEvaluated > 0 {
+				fmt.Fprintf(c.Stdout, "Resolver evaluated at request time: %d/%d secured operations\n", coverage.ResolverEvaluated, coverage.Secured)
+			}
+		} else {
+			fmt.Fprintf(c.Stdout, "Callable secured operations: %d/%d\n", coverage.Callable, coverage.Secured)
+		}
 	} else {
 		fmt.Fprintf(c.Stdout, "Operation metadata: %s (%s)\n", style.warn("unavailable"), style.hint("run \"restish api sync "+apiName+"\" to refresh"))
 	}
 	if len(ids) == 0 {
-		fmt.Fprintf(c.Stdout, "Credentials: %s\n", style.warn("none"))
+		label := "Credentials"
+		if coverage.ResolverEvaluated > 0 {
+			label = "Configured credentials"
+		}
+		fmt.Fprintf(c.Stdout, "%s: %s\n", label, style.warn("none"))
 	} else {
 		fmt.Fprintln(c.Stdout, "Credentials:")
 		for _, id := range ids {
@@ -137,7 +154,9 @@ func (c *CLI) printAPIAuthOverview(cmd *cobra.Command, apiName, profileName stri
 	if hasOps {
 		coverage := c.operationAuthCoverage(apiName, profileName, prof, set.Operations)
 		c.printAPIAuthRequirementSummary(apiName, profileName, set.Operations, prof, coverage)
-		if credentialID := nextMissingCredentialID(set.Operations, prof, coverage); credentialID != "" {
+		if coverage.ResolverEvaluated > 0 {
+			fmt.Fprintf(c.Stdout, "%s invoke a secured operation to evaluate the runtime auth resolver; if it declines, run \"restish api auth add %s <credential-id>\".\n", style.hint("Next:"), apiName)
+		} else if credentialID := nextMissingCredentialID(set.Operations, prof, coverage); credentialID != "" {
 			fmt.Fprintf(c.Stdout, "%s run \"restish api auth add %s %s\".\n", style.hint("Next:"), apiName, credentialID)
 		}
 	}
@@ -145,6 +164,11 @@ func (c *CLI) printAPIAuthOverview(cmd *cobra.Command, apiName, profileName stri
 
 func (c *CLI) runAPIAuthAdd(cmd *cobra.Command, args []string) error {
 	apiName, credentialID := args[0], args[1]
+	source, _ := cmd.Flags().GetString("source")
+	reference, _ := cmd.Flags().GetString("reference")
+	if (source == "") != (reference == "") {
+		return fmt.Errorf("--source and --reference must be supplied together")
+	}
 	profileName := c.profileFromCmd(cmd)
 	apiCfg, prof, err := c.apiProfileForAuth(apiName, profileName, true)
 	if err != nil {
@@ -164,11 +188,28 @@ func (c *CLI) runAPIAuthAdd(cmd *cobra.Command, args []string) error {
 			prof.Credentials[credentialID].Auth = authCfg
 		}
 	}
+	if source != "" && prof.Credentials[credentialID].Auth == nil {
+		return fmt.Errorf("credential %q has no OpenAPI DPoP security scheme; sync the API and use its published credential ID", credentialID)
+	}
 	if prof.Credentials[credentialID].Auth != nil {
+		if source != "" {
+			if prof.Credentials[credentialID].Auth.Type != "dpop" {
+				return fmt.Errorf("--source and --reference require a DPoP credential")
+			}
+			if prof.Credentials[credentialID].Auth.Params == nil {
+				prof.Credentials[credentialID].Auth.Params = map[string]string{}
+			}
+			prof.Credentials[credentialID].Auth.Params["source"] = source
+			prof.Credentials[credentialID].Auth.Params["reference"] = reference
+		}
 		if err := c.promptAuthParams(requestContext(cmd), profileName, credentialID, prof.Credentials[credentialID].Auth, defaultNeeds, configurePromptAnswers{}); err != nil {
 			return err
 		}
-		if len(defaultNeeds) > 0 {
+		if prof.Credentials[credentialID].Auth.Type == "dpop" {
+			delete(prof.Credentials[credentialID].Auth.Params, "scopes")
+			prof.Credentials[credentialID].Satisfies = nil
+		}
+		if len(defaultNeeds) > 0 && prof.Credentials[credentialID].Auth.Type != "dpop" {
 			if prof.Credentials[credentialID].Auth.Params == nil {
 				prof.Credentials[credentialID].Auth.Params = map[string]string{}
 			}
@@ -268,6 +309,10 @@ func (c *CLI) runAPIAuthInspect(cmd *cobra.Command, args []string) error {
 				continue
 			}
 		}
+		if dynamicDPoPConfig(target.Resolved.Config) {
+			c.printDynamicDPoPInspection(target.Resolved.Config, nil)
+			continue
+		}
 		req, err := c.authInspectionRequest(cmd, apiName, profileName, target.Resolved)
 		if err != nil {
 			return err
@@ -335,6 +380,10 @@ func (c *CLI) runAPIAuthInspectOperation(cmd *cobra.Command, apiName, profileNam
 		fmt.Fprintf(c.Stdout, "Operation: %s\nAuth: none (security: [{}])\n", op.ID)
 		return nil
 	}
+	if c.operationAuthDeferredToResolver(apiName, prof, op) {
+		c.printResolverDeferredOperationAuth(op)
+		return nil
+	}
 
 	var selected []selectedOperationAuth
 	if len(op.CredentialAlternatives) > 0 {
@@ -360,6 +409,17 @@ func (c *CLI) runAPIAuthInspectOperation(cmd *cobra.Command, apiName, profileNam
 		}
 		selected = []selectedOperationAuth{{requirement: spec.CredentialRequirement{ID: selectedCredential}, resolved: resolved, source: "profile auth"}}
 	}
+	if selectedOperationUsesDynamicDPoP(selected) {
+		fmt.Fprintf(c.Stdout, "Operation: %s\n", op.ID)
+		fmt.Fprintf(c.Stdout, "Credentials: %s\n", strings.Join(selectedOperationCredentialIDs(selected), ", "))
+		fmt.Fprintf(c.Stdout, "Source: %s\n", strings.Join(selectedOperationSources(selected), ", "))
+		for _, item := range selected {
+			if dynamicDPoPConfig(item.resolved.Config) {
+				c.printDynamicDPoPInspection(item.resolved.Config, item.requirement.Needs)
+			}
+		}
+		return nil
+	}
 
 	req, err := c.operationAuthInspectionRequest(cmd, apiName, profileName, selected)
 	if err != nil {
@@ -370,6 +430,29 @@ func (c *CLI) runAPIAuthInspectOperation(cmd *cobra.Command, apiName, profileNam
 	fmt.Fprintf(c.Stdout, "Source: %s\n", strings.Join(selectedOperationSources(selected), ", "))
 	c.printAuthInspectionRequest(req, selectedOperationAuthConfigs(selected), redact)
 	return nil
+}
+
+func dynamicDPoPConfig(config *config.AuthConfig) bool {
+	return config != nil && config.Type == "dpop" && config.Params["source"] != "" && config.Params["reference"] != ""
+}
+
+func selectedOperationUsesDynamicDPoP(selected []selectedOperationAuth) bool {
+	for _, item := range selected {
+		if dynamicDPoPConfig(item.resolved.Config) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *CLI) printDynamicDPoPInspection(config *config.AuthConfig, needs []string) {
+	fmt.Fprintln(c.Stdout, "Auth type: dpop")
+	fmt.Fprintf(c.Stdout, "Credential source: %s\n", config.Params["source"])
+	fmt.Fprintf(c.Stdout, "Credential reference: %s\n", config.Params["reference"])
+	if len(needs) > 0 {
+		fmt.Fprintf(c.Stdout, "Operation scopes: %s\n", strings.Join(needs, " "))
+	}
+	fmt.Fprintln(c.Stdout, "Auth material: evaluated when the operation is invoked")
 }
 
 func (c *CLI) runAPIAuthGet(cmd *cobra.Command, args []string) error {
@@ -653,7 +736,10 @@ func (c *CLI) operationAuthInspectionRequest(cmd *cobra.Command, apiName, profil
 	if err != nil {
 		return nil, err
 	}
-	req, _ := http.NewRequestWithContext(requestContext(cmd), "GET", "http://example.com", nil)
+	req, err := http.NewRequestWithContext(requestContext(cmd), http.MethodGet, c.authBaseURL(apiName, profileName), nil)
+	if err != nil {
+		return nil, fmt.Errorf("build auth inspection target: %w", err)
+	}
 	for _, item := range selected {
 		step, err := c.operationAuthStep(apiName, profileName, item, authOpts)
 		if err != nil {
@@ -670,6 +756,12 @@ func (c *CLI) applyOperationAuthInspectionStep(req *http.Request, s operationAut
 	params, err := c.buildAuthParams(s.rawParams)
 	if err != nil {
 		return err
+	}
+	if s.authType == "dpop" {
+		if params == nil {
+			params = map[string]string{}
+		}
+		params["scopes"] = strings.Join(s.needs, " ")
 	}
 	if s.authType == "external-tool" {
 		if err := c.ensureExternalToolApproved(req.Context(), s.apiName, s.profileName, params["commandline"]); err != nil {
@@ -692,7 +784,10 @@ func (c *CLI) authInspectionRequest(cmd *cobra.Command, apiName, profileName str
 	if err != nil {
 		return nil, err
 	}
-	req, _ := http.NewRequestWithContext(requestContext(cmd), "GET", "http://example.com", nil)
+	req, err := http.NewRequestWithContext(requestContext(cmd), http.MethodGet, c.authBaseURL(apiName, profileName), nil)
+	if err != nil {
+		return nil, fmt.Errorf("build auth inspection target: %w", err)
+	}
 	if err := handler.Authenticate(requestContext(cmd), req, c.authContext(requestContext(cmd), apiName, profileName, params, resolved.CacheKey, false)); err != nil {
 		return nil, fmt.Errorf("building auth inspection: %w", err)
 	}
@@ -984,8 +1079,15 @@ func (c *CLI) printAPIAuthRequirementSummary(apiName, profileName string, ops []
 				satisfies = credential.Satisfies
 			}
 		}
+		resolverDeferred := status == "missing" && !summary.undeclared && coverage.ResolverByID[summary.id] > 0
+		if resolverDeferred {
+			status = "unconfigured"
+		}
 		var parts []string
 		parts = append(parts, style.authStatus(status))
+		if resolverDeferred {
+			parts = append(parts, "resolver evaluated at request time")
+		}
 		if status == "missing" && coverage.FallbackByID[summary.id] > 0 {
 			parts = append(parts, coverage.FallbackLabels[summary.id])
 		}
@@ -995,7 +1097,7 @@ func (c *CLI) printAPIAuthRequirementSummary(apiName, profileName string, ops []
 		if len(satisfies) > 0 {
 			parts = append(parts, "satisfies "+strings.Join(satisfies, " "))
 		}
-		if !authRequirementKindSupported(summary.kind) {
+		if !authRequirementKindSupported(summary.kind) && !resolverDeferred {
 			parts = append(parts, "unsupported "+summary.kind)
 		}
 		if summary.undeclared {
@@ -1013,6 +1115,48 @@ func (c *CLI) printAPIAuthRequirementSummary(apiName, profileName string, ops []
 		}
 		parts = append(parts, fmt.Sprintf("%d %s", summary.opCount, operationWord))
 		fmt.Fprintf(c.Stdout, "  %s: %s\n", summary.id, strings.Join(parts, ", "))
+	}
+}
+
+func (c *CLI) operationAuthDeferredToResolver(apiName string, prof *config.ProfileConfig, op spec.Operation) bool {
+	if len(op.CredentialAlternatives) == 0 || !c.authResolverAvailable(apiName) {
+		return false
+	}
+	if prof == nil {
+		return true
+	}
+	if prof.Auth != nil || prof.AuthRef != "" {
+		return false
+	}
+	for _, alternative := range op.CredentialAlternatives {
+		for _, requirement := range alternative {
+			credential := prof.Credentials[requirement.ID]
+			if credential != nil && (credential.Auth != nil || credential.AuthRef != "") {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (c *CLI) printResolverDeferredOperationAuth(op spec.Operation) {
+	fmt.Fprintf(c.Stdout, "Operation: %s\n", op.ID)
+	if op.OptionalAuth {
+		fmt.Fprintln(c.Stdout, "Auth: optional; resolver evaluated at request time before anonymous fallback")
+	} else {
+		fmt.Fprintln(c.Stdout, "Auth: resolver evaluated at request time")
+	}
+	fmt.Fprintln(c.Stdout, "Security alternatives:")
+	for _, alternative := range op.CredentialAlternatives {
+		parts := make([]string, 0, len(alternative))
+		for _, requirement := range alternative {
+			part := requirement.ID
+			if len(requirement.Needs) > 0 {
+				part += " (needs " + strings.Join(requirement.Needs, " ") + ")"
+			}
+			parts = append(parts, part)
+		}
+		fmt.Fprintf(c.Stdout, "  - %s\n", strings.Join(parts, " + "))
 	}
 }
 
@@ -1088,7 +1232,7 @@ func mergeStringSet(existing, values []string) []string {
 
 func authRequirementKindSupported(kind string) bool {
 	switch kind {
-	case "api-key", "http-basic", "http-bearer", "oauth2", "mtls":
+	case "api-key", "http-basic", "http-bearer", "http-dpop", "oauth2", "oauth2-dpop", "mtls":
 		return true
 	default:
 		return false

--- a/internal/cli/api_auth_test.go
+++ b/internal/cli/api_auth_test.go
@@ -212,14 +212,14 @@ func TestAPIAuthInspectCredentialAPIKeyQuery(t *testing.T) {
 	app.SetConfigPath(cfgFile)
 	app.Run("api", "auth", "inspect", "myapi", "--credential", "PartnerKey")
 	got := app.Stdout.String()
-	if !strings.Contains(got, "Query: http://example.com?partner=secret") {
+	if !strings.Contains(got, "Query: https://api.example.com?partner=secret") {
 		t.Fatalf("expected API key query inspection to show value, got %q", got)
 	}
 
 	app.Stdout.Reset()
 	app.Run("api", "auth", "inspect", "myapi", "--credential", "PartnerKey", "--redact")
 	got = app.Stdout.String()
-	if strings.Contains(got, "secret") || !strings.Contains(got, "Query: http://example.com?partner=%3Credacted%3E") {
+	if strings.Contains(got, "secret") || !strings.Contains(got, "Query: https://api.example.com?partner=%3Credacted%3E") {
 		t.Fatalf("expected redacted API key query inspection with --redact, got %q", got)
 	}
 }
@@ -348,6 +348,33 @@ func TestAPIAuthInspectUsesCachedOperationMetadata(t *testing.T) {
 		"MutualTLS: missing, 1 operation",
 		"GhostAuth: missing, unsupported unknown, undeclared security scheme",
 		"urn:example:auth:TenantKey: missing, URI-backed",
+	)
+}
+
+func TestAPIAuthInspectDefersDynamicDPoPMaterialWithoutCallingTheSource(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	env := setupEnvWithSpec(t, mux, func(baseURL string) string {
+		return openAPISpec(baseURL, "DPoP API",
+			openAPISecuritySchemes(`"RealmrootOAuth":{"type":"oauth2","x-dpop-required":true,"flows":{"clientCredentials":{"tokenUrl":"https://identity.example/token","scopes":{"wallet:read":"Read Wallet"}}}}`),
+			openAPIPaths(openAPIGet("/wallet", "readWallet", `"security":[{"RealmrootOAuth":["wallet:read"]}]`)))
+	})
+	env.writeAPIConfig(t, testAPIConfig(env.baseURL(t), profileCredentials(map[string]*config.CredentialConfig{
+		"RealmrootOAuth": testCredential(&config.AuthConfig{Type: "dpop", Params: map[string]string{
+			"source": "missing-plugin", "reference": "https://identity.example/resources/wallet",
+		}}),
+	})))
+
+	c, out := env.newCaptureCLI()
+	if err := c.Run([]string{"restish", "api", "auth", "inspect", "tapi", "--operation", "readWallet", "--redact"}); err != nil {
+		t.Fatalf("api auth inspect: %v", err)
+	}
+	requireContains(t, out.String(),
+		"Operation: readWallet",
+		"Auth type: dpop",
+		"Credential source: missing-plugin",
+		"Operation scopes: wallet:read",
+		"Auth material: evaluated when the operation is invoked",
 	)
 }
 

--- a/internal/cli/api_configure_auth.go
+++ b/internal/cli/api_configure_auth.go
@@ -70,7 +70,11 @@ func (c *CLI) printAPIDiscovery(apiName, baseURL string, d configureAuthDiscover
 		if scheme.Kind == "mtls" {
 			details = append(details, "use TLS client certificate or signer")
 		} else if !scheme.Supported {
-			details = append(details, "unsupported")
+			if c.authResolverAvailable(apiName) {
+				details = append(details, "resolver evaluated at request time")
+			} else {
+				details = append(details, "unsupported")
+			}
 		}
 		if scheme.Deprecated {
 			details = append(details, "deprecated")
@@ -129,7 +133,11 @@ func (c *CLI) configureFallbackAuth(ctx context.Context, apiCfg *config.APIConfi
 		if err := c.promptAuthParams(ctx, "default", scheme.ID, credential.Auth, defaultNeeds, answers); err != nil {
 			return err
 		}
-		if len(defaultNeeds) > 0 {
+		if credential.Auth.Type == "dpop" {
+			delete(credential.Auth.Params, "scopes")
+			credential.Satisfies = nil
+		}
+		if len(defaultNeeds) > 0 && credential.Auth.Type != "dpop" {
 			if credential.Auth.Params == nil {
 				credential.Auth.Params = map[string]string{}
 			}
@@ -321,6 +329,9 @@ func defaultAuthParamValue(p auth.Param, defaultNeeds []string) string {
 }
 
 func authSatisfiesValues(defaultNeeds []string, ac *config.AuthConfig) []string {
+	if ac != nil && ac.Type == "dpop" {
+		return nil
+	}
 	if ac != nil && ac.Params != nil {
 		if scopes := uniqueStrings(strings.Fields(ac.Params["scopes"])); len(scopes) > 0 {
 			return scopes
@@ -519,11 +530,11 @@ func (c *CLI) printAuthCoverage(apiName, profileName string, apiCfg *config.APIC
 			skippedIDs = append(skippedIDs, scheme.ID)
 		}
 	}
-	var callable, secured int
+	var callable, secured, resolverEvaluated int
 	if apiCfg != nil {
 		prof := profileForName(apiCfg, profileName)
 		coverage := c.operationAuthCoverage(apiName, profileName, prof, d.operations)
-		callable, secured = coverage.Callable, coverage.Secured
+		callable, secured, resolverEvaluated = coverage.Callable, coverage.Secured, coverage.ResolverEvaluated
 	}
 	fmt.Fprintf(c.Stdout, "\nAuth coverage for profile %q:\n", profileName)
 	fmt.Fprintf(c.Stdout, "  configured: %s\n", formatIDList(configuredIDs))
@@ -531,7 +542,11 @@ func (c *CLI) printAuthCoverage(apiName, profileName string, apiCfg *config.APIC
 		fmt.Fprintf(c.Stdout, "  unresolved: %s\n", formatIDList(unresolved))
 	}
 	fmt.Fprintf(c.Stdout, "  skipped:    %s\n", formatIDList(skippedIDs))
-	fmt.Fprintf(c.Stdout, "  callable:   %d/%d secured operations\n\n", callable, secured)
+	fmt.Fprintf(c.Stdout, "  callable:   %d/%d secured operations\n", callable, secured)
+	if resolverEvaluated > 0 {
+		fmt.Fprintf(c.Stdout, "  resolver:   %d secured operations evaluated at request time\n", resolverEvaluated)
+	}
+	fmt.Fprintln(c.Stdout)
 }
 
 func (c *CLI) authCoverageCredentialStatus(apiName, profileName string, apiCfg *config.APIConfig, credentialID string) (string, bool) {

--- a/internal/cli/api_manage_test.go
+++ b/internal/cli/api_manage_test.go
@@ -3587,6 +3587,37 @@ func TestAPISyncWarnsAboutUndeclaredSecurityScheme(t *testing.T) {
 	}
 }
 
+func TestAPISyncRecognizesDPoPSecurityScheme(t *testing.T) {
+	c := newSpecTestCLI(t, "syncapi", "https://api.example.com")
+	useOpenAPISpecTransport(c, `{
+  "openapi": "3.1.0",
+  "info": {"title": "Test API", "version": "1.0"},
+  "components": {
+    "securitySchemes": {
+      "DPoP": {"type": "http", "scheme": "DPoP"}
+    }
+  },
+  "paths": {
+    "/wallet": {
+      "get": {
+        "operationId": "getWallet",
+        "security": [{"DPoP": []}],
+        "responses": {"200": {"description": "OK"}}
+      }
+    }
+  }
+}`)
+	var errOut strings.Builder
+	c.Stderr = &errOut
+
+	if err := c.Run([]string{"restish", "api", "sync", "syncapi"}); err != nil {
+		t.Fatalf("api sync: %v", err)
+	}
+	if strings.Contains(errOut.String(), "unsupported") {
+		t.Fatalf("unexpected unsupported security warning:\n%s", errOut.String())
+	}
+}
+
 func TestAPISyncNetworkFailureLeavesRegistrationAndCache(t *testing.T) {
 	c := newSpecTestCLI(t, "syncapi", "https://api.example.com")
 	cacheFile := filepath.Join(c.Hooks().SpecCachePath, "syncapi.cbor")

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -32,6 +32,7 @@ type authHandlerOptions struct {
 
 type authCallbacks struct {
 	OnRequest      func(*http.Request) error
+	OnRetryRequest func(*http.Request) error
 	OnUnauthorized func(*http.Request) error
 }
 
@@ -77,6 +78,8 @@ func (c *CLI) authHandlerFor(ac *config.AuthConfig, opts authHandlerOptions) (au
 		return &authpkg.Bearer{}, nil
 	case "http-basic":
 		return &authpkg.HTTPBasic{}, nil
+	case "dpop":
+		return &authpkg.DPoP{Source: pluginDPoPCredentialSource{cli: c}}, nil
 	case "oauth-client-credentials":
 		return &authpkg.ClientCredentials{
 			Cache:      auth.NewTokenCache(c.tokenCachePath()),
@@ -102,7 +105,7 @@ func (c *CLI) authHandlerFor(ac *config.AuthConfig, opts authHandlerOptions) (au
 	case "external-tool":
 		return &authpkg.ExternalTool{Stderr: c.Stderr}, nil
 	default:
-		return nil, fmt.Errorf("unknown auth type %q; supported: api-key, bearer, http-basic, oauth-client-credentials, oauth-authorization-code, oauth-device-code, external-tool", ac.Type)
+		return nil, fmt.Errorf("unknown auth type %q; supported: api-key, bearer, http-basic, dpop, oauth-client-credentials, oauth-authorization-code, oauth-device-code, external-tool", ac.Type)
 	}
 }
 
@@ -129,7 +132,7 @@ func (c *CLI) authOnRequest(apiName, profileName string, prof *config.ProfileCon
 				secretKeys[p.Name] = true
 			}
 		}
-		callbacks.OnRequest = func(req *http.Request) error {
+		apply := func(req *http.Request) error {
 			if c.applyCachedOAuthClientCredentials(req, resolvedAuth.Config.Type, resolvedAuth.CacheKey, apiName, profileName, false) {
 				return c.runAuthHookPlugins(apiName, profileName, rawParams, secretKeys, req)
 			}
@@ -154,6 +157,10 @@ func (c *CLI) authOnRequest(apiName, profileName string, prof *config.ProfileCon
 			}
 			markAuthCredentialTargets(req, resolvedAuth.Config.Type, params)
 			return c.runAuthHookPlugins(apiName, profileName, rawParams, secretKeys, req)
+		}
+		callbacks.OnRequest = apply
+		if _, ok := handler.(auth.RequestBound); ok {
+			callbacks.OnRetryRequest = apply
 		}
 		if _, ok := handler.(auth.ForceCapable); ok {
 			callbacks.OnUnauthorized = func(req *http.Request) error {

--- a/internal/cli/auth_readiness.go
+++ b/internal/cli/auth_readiness.go
@@ -81,10 +81,13 @@ func (c *CLI) profileAuthReadiness(apiName, profileName string, prof *config.Pro
 }
 
 type operationAuthCoverage struct {
-	Callable       int
-	Secured        int
-	FallbackByID   map[string]int
-	FallbackLabels map[string]string
+	Callable          int
+	Secured           int
+	SourceEvaluated   int
+	ResolverEvaluated int
+	ResolverByID      map[string]int
+	FallbackByID      map[string]int
+	FallbackLabels    map[string]string
 }
 
 type operationSecurityIssueKey struct {
@@ -94,6 +97,10 @@ type operationSecurityIssueKey struct {
 }
 
 func operationSecurityIssues(ops []spec.Operation) []string {
+	return operationSecurityIssuesWithResolver(ops, false)
+}
+
+func operationSecurityIssuesWithResolver(ops []spec.Operation, resolverAvailable bool) []string {
 	counts := map[operationSecurityIssueKey]int{}
 	for _, op := range ops {
 		seen := map[operationSecurityIssueKey]bool{}
@@ -101,6 +108,9 @@ func operationSecurityIssues(ops []spec.Operation) []string {
 			for _, requirement := range alternative {
 				text, ok := operationSecurityIssueText(requirement)
 				if !ok {
+					continue
+				}
+				if resolverAvailable && !requirement.Undeclared && !authRequirementKindSupported(requirement.Kind) {
 					continue
 				}
 				key := operationSecurityIssueKey{id: requirement.ID, kind: requirement.Kind, text: text}
@@ -172,6 +182,7 @@ func formatOperationSecurityIssues(counts map[operationSecurityIssueKey]int, uni
 
 func (c *CLI) operationAuthCoverage(apiName, profileName string, prof *config.ProfileConfig, ops []spec.Operation) operationAuthCoverage {
 	coverage := operationAuthCoverage{
+		ResolverByID:   map[string]int{},
 		FallbackByID:   map[string]int{},
 		FallbackLabels: map[string]string{},
 	}
@@ -182,10 +193,26 @@ func (c *CLI) operationAuthCoverage(apiName, profileName string, prof *config.Pr
 		coverage.Secured++
 		if op.OptionalAuth {
 			coverage.Callable++
-			continue
 		}
 		if c.operationHasUsableNamedAlternative(apiName, profileName, prof, op.CredentialAlternatives) {
-			coverage.Callable++
+			if !op.OptionalAuth {
+				coverage.Callable++
+			}
+			continue
+		}
+		if c.operationHasDynamicDPoPAlternative(apiName, profileName, prof, op.CredentialAlternatives) {
+			coverage.SourceEvaluated++
+			continue
+		}
+		if c.authResolverAvailable(apiName) {
+			coverage.ResolverEvaluated++
+			for _, alternative := range op.CredentialAlternatives {
+				for _, requirement := range alternative {
+					coverage.ResolverByID[requirement.ID]++
+				}
+			}
+		}
+		if op.OptionalAuth {
 			continue
 		}
 		policy := &operationAuthPolicy{OptionalAuth: op.OptionalAuth, CredentialAlternatives: op.CredentialAlternatives}
@@ -202,6 +229,40 @@ func (c *CLI) operationAuthCoverage(apiName, profileName string, prof *config.Pr
 		coverage.FallbackLabels[requirement.ID] = profileFallbackLabel(requirement, resolved.Config)
 	}
 	return coverage
+}
+
+func (c *CLI) operationHasDynamicDPoPAlternative(apiName, profileName string, prof *config.ProfileConfig, alternatives []spec.CredentialAlternative) bool {
+	if prof == nil {
+		return false
+	}
+	for _, alternative := range alternatives {
+		if len(alternative) == 0 {
+			continue
+		}
+		dynamic := true
+		for _, requirement := range alternative {
+			credential := prof.Credentials[requirement.ID]
+			resolved, ready, err := c.credentialReadiness(apiName, profileName, requirement.ID, credential)
+			if err != nil || !ready.Usable || resolved.Config == nil || resolved.Config.Type != "dpop" ||
+				resolved.Config.Params["source"] == "" || resolved.Config.Params["reference"] == "" {
+				dynamic = false
+				break
+			}
+		}
+		if dynamic {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *CLI) authResolverAvailable(apiName string) bool {
+	for _, resolver := range c.pluginsByHook["auth-resolver"] {
+		if pluginAppliesToAPI(resolver, apiName) {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *CLI) operationHasUsableNamedAlternative(apiName, profileName string, prof *config.ProfileConfig, alternatives []spec.CredentialAlternative) bool {
@@ -221,6 +282,10 @@ func (c *CLI) operationHasUsableNamedAlternative(apiName, profileName string, pr
 			credential := prof.Credentials[requirement.ID]
 			resolved, ready, err := c.credentialReadiness(apiName, profileName, requirement.ID, credential)
 			if err != nil || !ready.Usable || resolved.Config == nil {
+				ok = false
+				break
+			}
+			if resolved.Config.Type == "dpop" && resolved.Config.Params["source"] != "" && resolved.Config.Params["reference"] != "" {
 				ok = false
 				break
 			}
@@ -253,12 +318,16 @@ func profileFallbackObviouslyMatches(requirement spec.CredentialRequirement, ac 
 		case "bearer", "oauth-client-credentials", "oauth-authorization-code", "oauth-device-code", "external-tool":
 			return true
 		}
+	case "http-dpop":
+		return ac.Type == "dpop"
+	case "oauth2-dpop":
+		return ac.Type == "dpop"
 	case "http-basic":
 		return ac.Type == "http-basic"
 	case "api-key":
 		return ac.Type == "api-key"
 	case "oauth2":
-		return strings.HasPrefix(ac.Type, "oauth-")
+		return strings.HasPrefix(ac.Type, "oauth-") || ac.Type == "dpop"
 	}
 	return false
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -27,6 +27,7 @@ import (
 	"github.com/rest-sh/restish/v2/internal/output"
 	internalplugin "github.com/rest-sh/restish/v2/internal/plugin"
 	"github.com/rest-sh/restish/v2/internal/spec"
+	pluginwire "github.com/rest-sh/restish/v2/plugin"
 	"github.com/spf13/cobra"
 )
 
@@ -79,6 +80,8 @@ type testHooks struct {
 	SignalAwareContext func() (context.Context, context.CancelFunc)
 	// AuthHookFunc overrides auth hook plugin execution in tests.
 	AuthHookFunc func(apiName, profileName string, rawParams map[string]string, secretKeys map[string]bool, req *http.Request) error
+	// AuthResolverHookFunc overrides one auth-resolver plugin invocation in tests.
+	AuthResolverHookFunc func(internalplugin.Plugin, pluginwire.AuthResolverInput) (bool, error)
 	// StdoutIsTerminal overrides terminal detection in tests.
 	StdoutIsTerminal func(io.Writer) bool
 }

--- a/internal/cli/generated.go
+++ b/internal/cli/generated.go
@@ -491,7 +491,7 @@ func (c *CLI) buildOperationCommand(apiName, examplePrefix string, op spec.Opera
 			}
 			acceptOverride := c.generatedOperationAcceptHeader(op.ResponseMediaTypes, op.ResponseMediaType)
 			rawBinaryBody := op.Help.Request != nil && op.Help.Request.RawBinary
-			return c.runGeneratedOp(cmd, apiName, op.Path, op.OperationServer, op.Method, op.RequestMediaType, acceptOverride, op.RequestMultipartContentTypes, op.Help, op.BodyRequired, rawBinaryBody, op.NoAuth, op.OptionalAuth, op.CredentialAlternatives, required, optional, args)
+			return c.runGeneratedOp(cmd, apiName, op.Path, op.OperationServer, op.Method, op.RequestMediaType, acceptOverride, op.RequestMultipartContentTypes, op.Help, op.BodyRequired, rawBinaryBody, op.NoAuth, op.OptionalAuth, op.CredentialAlternatives, op.ConditionalSecurity, required, optional, args)
 		},
 	}
 	if candidates := authOverrideCandidates(op.OptionalAuth, op.CredentialAlternatives); len(candidates) > 0 {
@@ -1382,6 +1382,7 @@ func (c *CLI) runGeneratedOp(
 	noAuth bool,
 	optionalAuth bool,
 	credentialAlternatives []spec.CredentialAlternative,
+	conditionalSecurity []spec.ConditionalSecurityRule,
 	required, optional []*paramInfo,
 	args []string,
 ) error {
@@ -1511,6 +1512,8 @@ func (c *CLI) runGeneratedOp(
 			OptionalAuth:           optionalAuth,
 			NoAuth:                 noAuth,
 			CredentialAlternatives: credentialAlternatives,
+			OperationPath:          opPath,
+			ConditionalSecurity:    conditionalSecurity,
 			Override:               gf.Auth,
 		},
 	})

--- a/internal/cli/hooks.go
+++ b/internal/cli/hooks.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -10,9 +11,11 @@ import (
 	"path/filepath"
 	"strings"
 
+	authpkg "github.com/rest-sh/restish/v2/internal/auth"
 	"github.com/rest-sh/restish/v2/internal/output"
 	"github.com/rest-sh/restish/v2/internal/plugin"
 	"github.com/rest-sh/restish/v2/internal/request"
+	"github.com/rest-sh/restish/v2/internal/spec"
 	pluginwire "github.com/rest-sh/restish/v2/plugin"
 )
 
@@ -23,6 +26,72 @@ func (c *CLI) pluginForHook(name, hook string) (plugin.Plugin, bool) {
 		}
 	}
 	return plugin.Plugin{}, false
+}
+
+type pluginDPoPCredentialSource struct {
+	cli *CLI
+}
+
+func (s pluginDPoPCredentialSource) Describe(
+	ctx context.Context,
+	apiName, profileName, sourceName, reference string, scopes []string,
+) (authpkg.DPoPCredentialDescription, error) {
+	p, ok := s.cli.pluginForHook(sourceName, "credential-source")
+	if !ok {
+		return authpkg.DPoPCredentialDescription{}, fmt.Errorf("credential-source plugin %q is not installed", sourceName)
+	}
+	in := pluginwire.CredentialSourceInput{
+		Type: "credential-source", Action: "describe", API: apiName, Profile: profileName, Reference: reference,
+		Scopes: append([]string(nil), scopes...),
+	}
+	var out pluginwire.CredentialSourceOutput
+	if err := plugin.CallHookWithTimeoutContext(ctx, p.Path, plugin.HookTimeout(p.Manifest, "credential-source"), in, &out); err != nil {
+		return authpkg.DPoPCredentialDescription{}, fmt.Errorf("credential-source plugin %s: %w", p.Manifest.Name, err)
+	}
+	if out.Description == nil || out.Credential != nil || out.Challenge != nil {
+		return authpkg.DPoPCredentialDescription{}, fmt.Errorf("credential-source plugin %s returned an invalid describe response", p.Manifest.Name)
+	}
+	return authpkg.DPoPCredentialDescription{
+		ProofMethod: out.Description.ProofMethod,
+		ProofURI:    out.Description.ProofURI,
+		Resource:    out.Description.Resource,
+		Scopes:      append([]string(nil), out.Description.Scopes...),
+	}, nil
+}
+
+func (s pluginDPoPCredentialSource) Issue(
+	ctx context.Context,
+	apiName, profileName, sourceName, reference, proof string, scopes []string,
+) (authpkg.DPoPIssuedCredential, error) {
+	p, ok := s.cli.pluginForHook(sourceName, "credential-source")
+	if !ok {
+		return authpkg.DPoPIssuedCredential{}, fmt.Errorf("credential-source plugin %q is not installed", sourceName)
+	}
+	in := pluginwire.CredentialSourceInput{
+		Type: "credential-source", Action: "issue", API: apiName, Profile: profileName, Reference: reference, Proof: proof,
+		Scopes: append([]string(nil), scopes...),
+	}
+	var out pluginwire.CredentialSourceOutput
+	if err := plugin.CallHookWithTimeoutContext(ctx, p.Path, plugin.HookTimeout(p.Manifest, "credential-source"), in, &out); err != nil {
+		return authpkg.DPoPIssuedCredential{}, fmt.Errorf("credential-source plugin %s: %w", p.Manifest.Name, err)
+	}
+	if out.Challenge != nil {
+		if out.Credential != nil || out.Description != nil || out.Challenge.Type != "dpop-nonce" {
+			return authpkg.DPoPIssuedCredential{}, fmt.Errorf("credential-source plugin %s returned an invalid challenge response", p.Manifest.Name)
+		}
+		return authpkg.DPoPIssuedCredential{}, &authpkg.DPoPNonceChallenge{Nonce: out.Challenge.Nonce}
+	}
+	if out.Credential == nil || out.Description != nil {
+		return authpkg.DPoPIssuedCredential{}, fmt.Errorf("credential-source plugin %s returned an invalid issue response", p.Manifest.Name)
+	}
+	return authpkg.DPoPIssuedCredential{
+		AccessToken: out.Credential.AccessToken,
+		TokenType:   out.Credential.TokenType,
+		ExpiresAt:   out.Credential.ExpiresAt,
+		Resource:    out.Credential.Resource,
+		Scopes:      append([]string(nil), out.Credential.Scopes...),
+		Nonce:       out.Credential.Nonce,
+	}, nil
 }
 
 func indexPluginsByHook(plugins []plugin.Plugin) map[string][]plugin.Plugin {
@@ -51,6 +120,88 @@ func indexAuthPluginsByAPI(plugins []plugin.Plugin) ([]plugin.Plugin, map[string
 		}
 	}
 	return global, byAPI
+}
+
+func pluginAppliesToAPI(p plugin.Plugin, apiName string) bool {
+	if len(p.Manifest.AuthAPINames) == 0 {
+		return true
+	}
+	for _, name := range p.Manifest.AuthAPINames {
+		if name == apiName {
+			return true
+		}
+	}
+	return false
+}
+
+func pluginAuthRequirements(alternative spec.CredentialAlternative) []pluginwire.AuthRequirement {
+	requirements := make([]pluginwire.AuthRequirement, 0, len(alternative))
+	for _, requirement := range alternative {
+		requirements = append(requirements, pluginwire.AuthRequirement{
+			ID: requirement.ID, Ref: requirement.Ref, Kind: requirement.Kind,
+			Needs: append([]string(nil), requirement.Needs...), In: requirement.In,
+			Name: requirement.Name, Source: requirement.Source, External: requirement.External,
+			Undeclared: requirement.Undeclared, Deprecated: requirement.Deprecated,
+		})
+	}
+	return requirements
+}
+
+func (c *CLI) resolveOperationAuth(apiName, profileName string, policy *operationAuthPolicy) (selectedOperationAuth, bool, error) {
+	ctx := policy.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for _, alternative := range policy.CredentialAlternatives {
+		var claimed []plugin.Plugin
+		for _, p := range c.pluginsByHook["auth-resolver"] {
+			if !pluginAppliesToAPI(p, apiName) {
+				continue
+			}
+			in := pluginwire.AuthResolverInput{
+				Type: "auth-resolver", API: apiName, Profile: profileName,
+				Requirements: pluginAuthRequirements(alternative),
+				Request:      pluginwire.HookRequest{Method: policy.Method, URI: policy.URL, Headers: map[string][]string{}},
+			}
+			handled := false
+			var err error
+			if c.hooks.AuthResolverHookFunc != nil {
+				handled, err = c.hooks.AuthResolverHookFunc(p, in)
+			} else {
+				var out pluginwire.AuthResolverOutput
+				err = plugin.CallHookWithTimeoutContext(ctx, p.Path, plugin.HookTimeout(p.Manifest, "auth-resolver"), in, &out)
+				handled = out.Handled
+			}
+			if err != nil {
+				return selectedOperationAuth{}, false, fmt.Errorf("auth resolver plugin %s: %w", p.Manifest.Name, err)
+			}
+			if handled {
+				claimed = append(claimed, p)
+			}
+		}
+		if len(claimed) > 1 {
+			names := pluginNameList(claimed)
+			return selectedOperationAuth{}, false, fmt.Errorf("multiple auth resolver plugins claimed the same operation security alternative: %s", names)
+		}
+		if len(claimed) == 1 {
+			p := claimed[0]
+			return selectedOperationAuth{requirements: alternative, source: "auth resolver plugin " + p.Manifest.Name, resolver: &p}, true, nil
+		}
+	}
+	return selectedOperationAuth{}, false, nil
+}
+
+func (c *CLI) runSelectedAuthPlugin(p plugin.Plugin, apiName, profileName string, requirements []pluginwire.AuthRequirement, req *http.Request) error {
+	in := pluginwire.AuthHookInput{
+		Type: "auth", API: apiName, Profile: profileName, Requirements: requirements,
+		Request: hookRequestForPlugin(req, p),
+	}
+	var out pluginwire.AuthHookOutput
+	if err := plugin.CallHookWithTimeoutContext(req.Context(), p.Path, plugin.HookTimeout(p.Manifest, "auth"), in, &out); err != nil {
+		return fmt.Errorf("auth plugin %s: %w", p.Manifest.Name, err)
+	}
+	applyRequestUpdate(req, out.Request)
+	return nil
 }
 
 func pluginDeclaresHook(manifest plugin.Manifest, hook string) bool {

--- a/internal/cli/operation_auth.go
+++ b/internal/cli/operation_auth.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -21,6 +23,8 @@ type operationAuthPolicy struct {
 	OptionalAuth           bool
 	NoAuth                 bool
 	CredentialAlternatives []spec.CredentialAlternative
+	OperationPath          string
+	ConditionalSecurity    []spec.ConditionalSecurityRule
 	Override               string
 	Transport              request.Options
 }
@@ -34,6 +38,13 @@ type selectedOperationAuth struct {
 }
 
 func (c *CLI) planOperationAuth(apiName, profileName string, prof *config.ProfileConfig, policy *operationAuthPolicy) ([]selectedOperationAuth, bool, error) {
+	if policy != nil {
+		resolved, err := conditionalOperationAuthPolicy(*policy)
+		if err != nil {
+			return nil, false, err
+		}
+		policy = &resolved
+	}
 	if policy != nil && strings.TrimSpace(policy.Override) != "" {
 		return c.planOperationAuthOverride(apiName, profileName, prof, policy)
 	}
@@ -144,6 +155,61 @@ func (c *CLI) planOperationAuth(apiName, profileName string, prof *config.Profil
 	}
 	sort.Strings(missing)
 	return nil, false, fmt.Errorf("profile %q of API %q is missing credential bindings for this operation: %s%s%s; %s", profileName, apiName, strings.Join(uniqueStrings(missing), ", "), securityIssueSuffix, operationAuthConfiguredOverrideHint(prof, policy.CredentialAlternatives), operationAuthSetupHint(apiName, profileName))
+}
+
+func conditionalOperationAuthPolicy(policy operationAuthPolicy) (operationAuthPolicy, error) {
+	if len(policy.ConditionalSecurity) == 0 || policy.URL == "" {
+		return policy, nil
+	}
+	u, err := url.Parse(policy.URL)
+	if err != nil {
+		return operationAuthPolicy{}, fmt.Errorf("conditional operation security: parse request URL: %w", err)
+	}
+	for _, rule := range policy.ConditionalSecurity {
+		value, ok := operationPathParameter(policy.OperationPath, u.EscapedPath(), rule.When.PathParameter)
+		if !ok || !strings.HasPrefix(value, rule.When.Prefix) {
+			continue
+		}
+		alternatives := make([]spec.CredentialAlternative, 0, len(rule.Alternatives))
+		for _, index := range rule.Alternatives {
+			if index < 0 || index >= len(policy.CredentialAlternatives) {
+				return operationAuthPolicy{}, fmt.Errorf("conditional operation security selects unavailable alternative %d", index)
+			}
+			alternatives = append(alternatives, policy.CredentialAlternatives[index])
+		}
+		policy.CredentialAlternatives = alternatives
+		return policy, nil
+	}
+	return policy, nil
+}
+
+func operationPathParameter(template, escapedRequestPath, name string) (string, bool) {
+	var source strings.Builder
+	source.WriteString(`^.*`)
+	index := 0
+	found := false
+	for _, match := range regexp.MustCompile(`\{([^}]+)\}`).FindAllStringSubmatchIndex(template, -1) {
+		source.WriteString(regexp.QuoteMeta(template[index:match[0]]))
+		parameterName := template[match[2]:match[3]]
+		if parameterName == name {
+			source.WriteString(`(.+)`)
+			found = true
+		} else {
+			source.WriteString(`[^/]+`)
+		}
+		index = match[1]
+	}
+	if !found {
+		return "", false
+	}
+	source.WriteString(regexp.QuoteMeta(template[index:]))
+	source.WriteString(`$`)
+	match := regexp.MustCompile(source.String()).FindStringSubmatch(escapedRequestPath)
+	if len(match) != 2 {
+		return "", false
+	}
+	value, err := url.PathUnescape(match[1])
+	return value, err == nil
 }
 
 func (c *CLI) planOperationAuthOverride(apiName, profileName string, prof *config.ProfileConfig, policy *operationAuthPolicy) ([]selectedOperationAuth, bool, error) {

--- a/internal/cli/operation_auth.go
+++ b/internal/cli/operation_auth.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"sort"
@@ -8,11 +9,15 @@ import (
 
 	"github.com/rest-sh/restish/v2/auth"
 	"github.com/rest-sh/restish/v2/config"
+	internalplugin "github.com/rest-sh/restish/v2/internal/plugin"
 	"github.com/rest-sh/restish/v2/internal/request"
 	"github.com/rest-sh/restish/v2/internal/spec"
 )
 
 type operationAuthPolicy struct {
+	Context                context.Context
+	Method                 string
+	URL                    string
 	OptionalAuth           bool
 	NoAuth                 bool
 	CredentialAlternatives []spec.CredentialAlternative
@@ -21,9 +26,11 @@ type operationAuthPolicy struct {
 }
 
 type selectedOperationAuth struct {
-	requirement spec.CredentialRequirement
-	resolved    resolvedAuthConfig
-	source      string
+	requirement  spec.CredentialRequirement
+	requirements spec.CredentialAlternative
+	resolved     resolvedAuthConfig
+	source       string
+	resolver     *internalplugin.Plugin
 }
 
 func (c *CLI) planOperationAuth(apiName, profileName string, prof *config.ProfileConfig, policy *operationAuthPolicy) ([]selectedOperationAuth, bool, error) {
@@ -92,6 +99,15 @@ func (c *CLI) planOperationAuth(apiName, profileName string, prof *config.Profil
 				return nil, false, err
 			}
 			return selected, true, nil
+		}
+	}
+	if policy.URL != "" {
+		resolved, ok, err := c.resolveOperationAuth(apiName, profileName, policy)
+		if err != nil {
+			return nil, false, err
+		}
+		if ok {
+			return []selectedOperationAuth{resolved}, true, nil
 		}
 	}
 
@@ -319,6 +335,14 @@ func (c *CLI) operationAuthCallbacks(apiName, profileName string, selected []sel
 	if len(selected) == 0 {
 		return authCallbacks{}, nil
 	}
+	if len(selected) == 1 && selected[0].resolver != nil {
+		resolver := *selected[0].resolver
+		requirements := pluginAuthRequirements(selected[0].requirements)
+		apply := func(req *http.Request) error {
+			return c.runSelectedAuthPlugin(resolver, apiName, profileName, requirements, req)
+		}
+		return authCallbacks{OnRequest: apply, OnRetryRequest: apply}, nil
+	}
 	steps := make([]operationAuthStep, 0, len(selected))
 	for _, item := range selected {
 		step, err := c.operationAuthStep(apiName, profileName, item, opts)
@@ -336,6 +360,12 @@ func (c *CLI) operationAuthCallbacks(apiName, profileName string, selected []sel
 			}
 			return c.runOperationAuthHookPlugins(req, steps)
 		},
+	}
+	for _, step := range steps {
+		if step.requestBound {
+			callbacks.OnRetryRequest = callbacks.OnRequest
+			break
+		}
 	}
 	for _, step := range steps {
 		if step.forceCapable {
@@ -373,10 +403,12 @@ type operationAuthStep struct {
 	rawParams    map[string]string
 	cacheKey     string
 	forceCapable bool
+	requestBound bool
 	secretKeys   map[string]bool
 	apiName      string
 	profileName  string
 	authType     string
+	needs        []string
 }
 
 func (c *CLI) operationAuthStep(apiName, profileName string, selected selectedOperationAuth, opts authHandlerOptions) (operationAuthStep, error) {
@@ -391,15 +423,18 @@ func (c *CLI) operationAuthStep(apiName, profileName string, selected selectedOp
 		}
 	}
 	_, forceCapable := handler.(auth.ForceCapable)
+	_, requestBound := handler.(auth.RequestBound)
 	return operationAuthStep{
 		handler:      handler,
 		rawParams:    selected.resolved.Config.Params,
 		cacheKey:     selected.resolved.CacheKey,
 		forceCapable: forceCapable,
+		requestBound: requestBound,
 		secretKeys:   secretKeys,
 		apiName:      apiName,
 		profileName:  profileName,
 		authType:     selected.resolved.Config.Type,
+		needs:        append([]string(nil), selected.requirement.Needs...),
 	}, nil
 }
 
@@ -410,6 +445,12 @@ func (c *CLI) applyOperationAuthStep(req *http.Request, s operationAuthStep, for
 	params, err := c.buildAuthParams(s.rawParams)
 	if err != nil {
 		return err
+	}
+	if s.authType == "dpop" {
+		if params == nil {
+			params = map[string]string{}
+		}
+		params["scopes"] = strings.Join(s.needs, " ")
 	}
 	if s.authType == "external-tool" {
 		if err := c.ensureExternalToolApproved(req.Context(), s.apiName, s.profileName, params["commandline"]); err != nil {
@@ -432,6 +473,9 @@ func (c *CLI) applyOperationAuthStep(req *http.Request, s operationAuthStep, for
 
 func credentialSatisfies(requirement spec.CredentialRequirement, credential *config.CredentialConfig, authCfg *config.AuthConfig) error {
 	if len(requirement.Needs) == 0 {
+		return nil
+	}
+	if authCfg != nil && authCfg.Type == "dpop" && authCfg.Params["source"] != "" && authCfg.Params["reference"] != "" {
 		return nil
 	}
 	satisfies := credential.Satisfies
@@ -583,7 +627,7 @@ func authMutationKey(ac *config.AuthConfig) string {
 		default:
 			return ""
 		}
-	case "bearer", "http-basic", "oauth-client-credentials", "oauth-authorization-code", "oauth-device-code":
+	case "bearer", "http-basic", "dpop", "oauth-client-credentials", "oauth-authorization-code", "oauth-device-code":
 		return "header:authorization"
 	case "external-tool":
 		// External tools may return complete header/query mutations, so the

--- a/internal/cli/operation_auth_test.go
+++ b/internal/cli/operation_auth_test.go
@@ -9,8 +9,10 @@ import (
 
 	"github.com/rest-sh/restish/v2/auth"
 	"github.com/rest-sh/restish/v2/config"
+	internalplugin "github.com/rest-sh/restish/v2/internal/plugin"
 	"github.com/rest-sh/restish/v2/internal/request"
 	"github.com/rest-sh/restish/v2/internal/spec"
+	pluginwire "github.com/rest-sh/restish/v2/plugin"
 )
 
 type forceRecordingAuth struct {
@@ -466,6 +468,30 @@ func TestOperationAuthCoverageCountsOptionalAnonymousAsCallable(t *testing.T) {
 	}
 }
 
+func TestOperationAuthCoverageDefersConfiguredDPoPSourcePerRequest(t *testing.T) {
+	c := &CLI{}
+	prof := &config.ProfileConfig{Credentials: map[string]*config.CredentialConfig{
+		"RealmrootOAuth": {
+			Auth: &config.AuthConfig{Type: "dpop", Params: map[string]string{
+				"source": "realmroot", "reference": "https://identity.example/resources/wallet",
+			}},
+		},
+	}}
+	ops := []spec.Operation{
+		{ID: "readWallet", CredentialAlternatives: []spec.CredentialAlternative{{{
+			ID: "RealmrootOAuth", Kind: "oauth2-dpop", Needs: []string{"wallet:read"},
+		}}}},
+		{ID: "pay", CredentialAlternatives: []spec.CredentialAlternative{{{
+			ID: "RealmrootOAuth", Kind: "oauth2-dpop", Needs: []string{"wallet:x402:pay"},
+		}}}},
+	}
+
+	coverage := c.operationAuthCoverage("wallet", "default", prof, ops)
+	if coverage.Callable != 0 || coverage.SourceEvaluated != 2 || coverage.Secured != 2 {
+		t.Fatalf("coverage = %#v, want 0 statically callable and 2 source-evaluated", coverage)
+	}
+}
+
 func TestOperationAuthCoverageCountsProfileMTLSAsCallable(t *testing.T) {
 	c := &CLI{}
 	prof := &config.ProfileConfig{
@@ -702,5 +728,110 @@ func TestOperationAuthPreserveHeaderCaseDoesNotRewriteManualHeader(t *testing.T)
 	}
 	if got := req.Header["X-Sourcesystem"]; len(got) != 0 {
 		t.Fatalf("operation auth added canonicalized duplicate: %#v", req.Header)
+	}
+}
+
+func TestPlanOperationAuthUsesResolverOnlyAfterConfiguredCredentialsFail(t *testing.T) {
+	resolver := internalplugin.Plugin{Path: "/resolver", Manifest: pluginwire.Manifest{Name: "vault", Hooks: []string{"auth-resolver", "auth"}}}
+	c := &CLI{pluginsByHook: map[string][]internalplugin.Plugin{"auth-resolver": {resolver}}}
+	var received pluginwire.AuthResolverInput
+	c.hooks.AuthResolverHookFunc = func(_ internalplugin.Plugin, input pluginwire.AuthResolverInput) (bool, error) {
+		received = input
+		return true, nil
+	}
+	policy := &operationAuthPolicy{
+		Context: context.Background(), Method: http.MethodGet, URL: "https://api.example.com/v1/projects",
+		CredentialAlternatives: []spec.CredentialAlternative{{{ID: "OAuth", Kind: "oauth2", Needs: []string{"projects:read"}}}},
+	}
+	selected, handled, err := c.planOperationAuth("projects", "default", nil, policy)
+	if err != nil {
+		t.Fatalf("planOperationAuth: %v", err)
+	}
+	if !handled || len(selected) != 1 || selected[0].resolver == nil || selected[0].resolver.Manifest.Name != "vault" {
+		t.Fatalf("selected resolver = %#v, handled = %v", selected, handled)
+	}
+	if received.Request.URI != policy.URL || received.Request.Method != http.MethodGet || len(received.Requirements) != 1 || received.Requirements[0].Needs[0] != "projects:read" {
+		t.Fatalf("resolver input = %#v", received)
+	}
+
+	called := false
+	c.hooks.AuthResolverHookFunc = func(_ internalplugin.Plugin, _ pluginwire.AuthResolverInput) (bool, error) {
+		called = true
+		return true, nil
+	}
+	profile := &config.ProfileConfig{Credentials: map[string]*config.CredentialConfig{
+		"OAuth": {Auth: &config.AuthConfig{Type: "api-key", Params: map[string]string{"in": "header", "name": "Authorization", "value": "Bearer configured"}}, Satisfies: []string{"projects:read"}},
+	}}
+	selected, handled, err = c.planOperationAuth("projects", "default", profile, policy)
+	if err != nil || !handled || len(selected) != 1 {
+		t.Fatalf("configured plan = %#v, handled = %v, err = %v", selected, handled, err)
+	}
+	if called || selected[0].resolver != nil {
+		t.Fatal("resolver must not override a configured credential")
+	}
+}
+
+func TestAPIAuthInspectDefersUnconfiguredOperationToResolver(t *testing.T) {
+	var out strings.Builder
+	c := &CLI{
+		Stdout: &out,
+		pluginsByHook: map[string][]internalplugin.Plugin{"auth-resolver": {{
+			Manifest: pluginwire.Manifest{Name: "vault", Hooks: []string{"auth-resolver", "auth"}},
+		}}},
+	}
+	op := spec.Operation{
+		ID: "listProjects",
+		CredentialAlternatives: []spec.CredentialAlternative{
+			{{ID: "OIDC", Kind: "openid", Needs: []string{"projects:read"}}},
+			{{ID: "Session", Kind: "api-key"}},
+		},
+	}
+	if !c.operationAuthDeferredToResolver("projects", &config.ProfileConfig{}, op) {
+		t.Fatal("expected operation auth inspection to defer to the resolver")
+	}
+	c.printResolverDeferredOperationAuth(op)
+	got := out.String()
+	for _, want := range []string{
+		"Operation: listProjects",
+		"Auth: resolver evaluated at request time",
+		"OIDC (needs projects:read)",
+		"Session",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output = %q, want %q", got, want)
+		}
+	}
+}
+
+func TestAPIAuthInspectDoesNotHideConfiguredCredentialErrorsBehindResolver(t *testing.T) {
+	c := &CLI{pluginsByHook: map[string][]internalplugin.Plugin{"auth-resolver": {{
+		Manifest: pluginwire.Manifest{Name: "vault", Hooks: []string{"auth-resolver", "auth"}},
+	}}}}
+	op := spec.Operation{
+		ID: "listProjects",
+		CredentialAlternatives: []spec.CredentialAlternative{{{
+			ID: "OIDC", Kind: "oauth2", Needs: []string{"projects:read"},
+		}}},
+	}
+	profile := &config.ProfileConfig{Credentials: map[string]*config.CredentialConfig{
+		"OIDC": {Auth: &config.AuthConfig{Type: "bearer", Params: map[string]string{"token": "env:MISSING"}}},
+	}}
+	if c.operationAuthDeferredToResolver("projects", profile, op) {
+		t.Fatal("configured credential inspection must retain strict readiness errors")
+	}
+}
+
+func TestPlanOperationAuthRejectsAmbiguousResolvers(t *testing.T) {
+	c := &CLI{pluginsByHook: map[string][]internalplugin.Plugin{"auth-resolver": {
+		{Manifest: pluginwire.Manifest{Name: "first"}},
+		{Manifest: pluginwire.Manifest{Name: "second"}},
+	}}}
+	c.hooks.AuthResolverHookFunc = func(_ internalplugin.Plugin, _ pluginwire.AuthResolverInput) (bool, error) { return true, nil }
+	_, _, err := c.planOperationAuth("projects", "default", nil, &operationAuthPolicy{
+		Method: http.MethodGet, URL: "https://api.example.com/projects",
+		CredentialAlternatives: []spec.CredentialAlternative{{{ID: "OAuth", Kind: "oauth2"}}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "multiple auth resolver plugins") {
+		t.Fatalf("error = %v", err)
 	}
 }

--- a/internal/cli/operation_auth_test.go
+++ b/internal/cli/operation_auth_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"net/http"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -76,6 +77,44 @@ func TestPlanOperationAuthDerivesSatisfiesFromAuthProfileScopes(t *testing.T) {
 	}
 	if !handled || len(selected) != 1 || selected[0].resolved.Ref != "shared-oauth" {
 		t.Fatalf("selected = %#v handled=%v, want shared auth profile", selected, handled)
+	}
+}
+
+func TestPlanOperationAuthSelectsConditionalAlternativeFromConcretePath(t *testing.T) {
+	c := &CLI{}
+	prof := &config.ProfileConfig{Credentials: map[string]*config.CredentialConfig{
+		"provider": {
+			Auth:      &config.AuthConfig{Type: "api-key", Params: map[string]string{"in": "header", "name": "Authorization", "value": "token"}},
+			Satisfies: []string{"contents:write", "workflows:write"},
+		},
+	}}
+	policy := operationAuthPolicy{
+		URL:           "https://adapter.example.com/github/repos/acme/widgets/contents/.github/workflows/release.yml",
+		OperationPath: "/repos/{owner}/{repo}/contents/{path}",
+		CredentialAlternatives: []spec.CredentialAlternative{
+			{{ID: "provider", Needs: []string{"contents:write"}}},
+			{{ID: "provider", Needs: []string{"contents:write", "workflows:write"}}},
+		},
+		ConditionalSecurity: []spec.ConditionalSecurityRule{{
+			When:         spec.ConditionalSecurityPredicate{PathParameter: "path", Prefix: ".github/workflows/"},
+			Alternatives: []int{1},
+		}},
+	}
+	selected, handled, err := c.planOperationAuth("github", "default", prof, &policy)
+	if err != nil {
+		t.Fatalf("planOperationAuth: %v", err)
+	}
+	if !handled || len(selected) != 1 || !reflect.DeepEqual(selected[0].requirement.Needs, []string{"contents:write", "workflows:write"}) {
+		t.Fatalf("selected = %#v handled=%v, want workflow conjunction", selected, handled)
+	}
+
+	policy.URL = "https://adapter.example.com/github/repos/acme/widgets/contents/README.md"
+	selected, handled, err = c.planOperationAuth("github", "default", prof, &policy)
+	if err != nil {
+		t.Fatalf("planOperationAuth ordinary path: %v", err)
+	}
+	if !handled || len(selected) != 1 || !reflect.DeepEqual(selected[0].requirement.Needs, []string{"contents:write"}) {
+		t.Fatalf("selected = %#v handled=%v, want ordinary contents authority", selected, handled)
 	}
 }
 

--- a/internal/cli/operation_route_auth.go
+++ b/internal/cli/operation_route_auth.go
@@ -44,7 +44,7 @@ func (c *CLI) operationAuthForGenericRequest(ctx context.Context, method, rawURL
 		if !ok {
 			continue
 		}
-		score, ok := routeTemplateMatchScore(routePath, requestPath)
+		score, ok := routeTemplateMatchScore(routePath, requestPath, conditionalSecurityPathParameters(op.ConditionalSecurity))
 		if !ok || score < bestScore {
 			continue
 		}
@@ -69,6 +69,8 @@ func (c *CLI) operationAuthForGenericRequest(ctx context.Context, method, rawURL
 		policy: &operationAuthPolicy{
 			OptionalAuth:           best.OptionalAuth,
 			CredentialAlternatives: best.CredentialAlternatives,
+			OperationPath:          best.Path,
+			ConditionalSecurity:    best.ConditionalSecurity,
 		},
 	}, true
 }
@@ -112,7 +114,7 @@ func operationRoutePath(apiCfg *config.APIConfig, profileName, opPath string) (s
 	return urlpath.Clean(path), true
 }
 
-func routeTemplateMatchScore(templatePath, requestPath string) (int, bool) {
+func routeTemplateMatchScore(templatePath, requestPath string, greedyParameters map[string]bool) (int, bool) {
 	templatePath = urlpath.Clean(templatePath)
 	requestPath = urlpath.Clean(requestPath)
 	if templatePath == requestPath && !strings.Contains(templatePath, "{") {
@@ -120,12 +122,25 @@ func routeTemplateMatchScore(templatePath, requestPath string) (int, bool) {
 	}
 	templateSegments := splitCleanPath(templatePath)
 	requestSegments := splitCleanPath(requestPath)
-	if len(templateSegments) != len(requestSegments) {
+	greedyName := ""
+	if len(templateSegments) > 0 {
+		last := templateSegments[len(templateSegments)-1]
+		if strings.HasPrefix(last, "{") && strings.HasSuffix(last, "}") {
+			name := strings.TrimSuffix(strings.TrimPrefix(last, "{"), "}")
+			if greedyParameters[name] {
+				greedyName = name
+			}
+		}
+	}
+	if len(templateSegments) != len(requestSegments) && (greedyName == "" || len(requestSegments) < len(templateSegments)) {
 		return 0, false
 	}
 	score := 0
 	for i, templateSegment := range templateSegments {
 		requestSegment := requestSegments[i]
+		if i == len(templateSegments)-1 && greedyName != "" {
+			requestSegment = strings.Join(requestSegments[i:], "/")
+		}
 		if strings.Contains(templateSegment, "{") && strings.Contains(templateSegment, "}") {
 			if requestSegment == "" {
 				return 0, false
@@ -139,6 +154,14 @@ func routeTemplateMatchScore(templatePath, requestPath string) (int, bool) {
 		score += len(templateSegment) * 4
 	}
 	return score, true
+}
+
+func conditionalSecurityPathParameters(rules []spec.ConditionalSecurityRule) map[string]bool {
+	parameters := map[string]bool{}
+	for _, rule := range rules {
+		parameters[rule.When.PathParameter] = true
+	}
+	return parameters
 }
 
 func splitCleanPath(p string) []string {

--- a/internal/cli/operation_route_auth_test.go
+++ b/internal/cli/operation_route_auth_test.go
@@ -1,0 +1,23 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/rest-sh/restish/v2/internal/spec"
+)
+
+func TestConditionalSecurityPathParameterMatchesSlashContainingGenericRequest(t *testing.T) {
+	rules := []spec.ConditionalSecurityRule{{
+		When:         spec.ConditionalSecurityPredicate{PathParameter: "path", Prefix: ".github/workflows/"},
+		Alternatives: []int{1},
+	}}
+	template := "/github/repos/{owner}/{repo}/contents/{path}"
+	requestPath := "/github/repos/acme/widgets/contents/.github/workflows/release.yml"
+
+	if _, ok := routeTemplateMatchScore(template, requestPath, conditionalSecurityPathParameters(rules)); !ok {
+		t.Fatal("conditional path parameter did not consume the remaining generic request path")
+	}
+	if _, ok := routeTemplateMatchScore(template, requestPath, nil); ok {
+		t.Fatal("ordinary OpenAPI path parameters must still consume exactly one segment")
+	}
+}

--- a/internal/cli/request_exec.go
+++ b/internal/cli/request_exec.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/rest-sh/restish/v2/config"
+	authpkg "github.com/rest-sh/restish/v2/internal/auth"
 	"github.com/rest-sh/restish/v2/internal/hypermedia"
 	"github.com/rest-sh/restish/v2/internal/output"
 	"github.com/rest-sh/restish/v2/internal/request"
@@ -74,6 +75,13 @@ func (c *CLI) prepareRequest(
 		}
 	}
 	explicitOperationAuthOverride := operationAuth != nil && strings.TrimSpace(operationAuth.Override) != ""
+	if apiName != "" {
+		rewritten, _, err := config.ApplyURLOverrides(rawURL, effectiveURLOverrides(c.cfg.APIs[apiName], profileName))
+		if err != nil {
+			return nil, fmt.Errorf("url_overrides: %w", err)
+		}
+		rawURL = rewritten
+	}
 	if (!noAuth || explicitOperationAuthOverride) && operationAuth != nil && apiName != "" {
 		prof := profileForName(c.cfg.APIs[apiName], profileName)
 		policy := *operationAuth
@@ -81,6 +89,9 @@ func (c *CLI) prepareRequest(
 			policy.NoAuth = true
 		}
 		policy.Transport = opts
+		policy.Context = ctx
+		policy.Method = method
+		policy.URL = rawURL
 		selected, handled, err := c.planOperationAuth(apiName, profileName, prof, &policy)
 		if err != nil {
 			return nil, err
@@ -94,15 +105,21 @@ func (c *CLI) prepareRequest(
 				return nil, err
 			}
 			opts.OnRequest = callbacks.OnRequest
+			if callbacks.OnRetryRequest != nil {
+				authorizedURL, parseErr := url.Parse(rawURL)
+				if parseErr != nil {
+					return nil, fmt.Errorf("operation auth target: %w", parseErr)
+				}
+				retryAuth := callbacks.OnRetryRequest
+				opts.OnRetryRequest = func(req *http.Request) error {
+					if !request.SameOrigin(authorizedURL, req.URL) {
+						return nil
+					}
+					return retryAuth(req)
+				}
+			}
 			opts.OnUnauthorized = callbacks.OnUnauthorized
 		}
-	}
-	if apiName != "" {
-		rewritten, _, err := config.ApplyURLOverrides(rawURL, effectiveURLOverrides(c.cfg.APIs[apiName], profileName))
-		if err != nil {
-			return nil, fmt.Errorf("url_overrides: %w", err)
-		}
-		rawURL = rewritten
 	}
 	opts, err = c.resolveTLSSigner(opts)
 	if err != nil {
@@ -129,6 +146,7 @@ func (c *CLI) prepareRequest(
 	// a compromised plugin from issuing credentialed requests to arbitrary hosts.
 	if noAuth {
 		opts.OnRequest = nil
+		opts.OnRetryRequest = nil
 		opts.OnUnauthorized = nil
 		filtered := opts.Headers[:0]
 		for _, h := range opts.Headers {
@@ -356,7 +374,9 @@ func (c *CLI) sendPreparedRequest(ctx context.Context, method string, prepared *
 	retryOpts := cloneRequestOptions(prepared.opts)
 	retryOpts.Transport = prepared.opts.Transport
 	onUnauthorized := retryOpts.OnUnauthorized
+	nonce := resp.Header.Get("DPoP-Nonce")
 	retryOpts.OnRequest = func(req *http.Request) error {
+		authpkg.SetDPoPNonce(req, nonce)
 		if err := onUnauthorized(req); err != nil {
 			return err
 		}

--- a/internal/cli/testdata/testplugin/main.go
+++ b/internal/cli/testdata/testplugin/main.go
@@ -171,7 +171,8 @@ func runHookPlugin() {
 		Version:            "1.0.0",
 		Description:        "Test hook plugin",
 		RestishAPIVersion:  2,
-		Hooks:              []string{"auth", "request-middleware", "response-middleware", "formatter", "loader"},
+		Hooks:              []string{"auth-resolver", "auth", "request-middleware", "response-middleware", "formatter", "loader"},
+		RequiredFeatures:   []string{plugin.FeatureAuthOperationSecurity},
 		FormatterNames:     []string{"hookformat"},
 		LoaderContentTypes: []string{"application/x-hook-api"},
 	}
@@ -190,6 +191,15 @@ func runHookPlugin() {
 	}
 
 	switch plugin.MessageType(raw) {
+	case "auth-resolver":
+		var msg plugin.AuthResolverInput
+		_ = plugin.DecMode.Unmarshal(raw, &msg)
+		handled := os.Getenv("RSH_HOOK_RESOLVE_AUTH") == "1"
+		if handled && len(msg.Requirements) != 1 {
+			fmt.Fprintf(os.Stderr, "resolver requirements = %#v\n", msg.Requirements)
+			os.Exit(1)
+		}
+		_ = plugin.WriteMessage(os.Stdout, plugin.AuthResolverOutput{Handled: handled})
 	case "auth":
 		var msg plugin.AuthHookInput
 		_ = plugin.DecMode.Unmarshal(raw, &msg)

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -35,7 +35,9 @@ const (
 )
 
 var knownHooks = map[string]bool{
+	"auth-resolver":       true,
 	"auth":                true,
+	"credential-source":   true,
 	"request-middleware":  true,
 	"response-middleware": true,
 	"loader":              true,
@@ -48,6 +50,9 @@ var supportedRequiredFeatures = map[string]bool{
 	pluginwire.FeatureManifestRequiredFeatures: true,
 	pluginwire.FeatureLoaderSourceMetadata:     true,
 	pluginwire.FeatureRequestFinalBody:         true,
+	pluginwire.FeatureAuthOperationSecurity:    true,
+	pluginwire.FeatureDPoPCredentialSource:     true,
+	pluginwire.FeatureDPoPOperationScopes:      true,
 }
 
 var renameManifestCacheFile = os.Rename

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -284,6 +284,10 @@ func TestLoadManifest_CompatibilityMatrix(t *testing.T) {
 			name: "supported required feature",
 			json: `{"name":"supported","restish_api_version":2,"hooks":["loader"],"loader_content_types":["application/x-test"],"required_features":["loader.source_metadata"]}`,
 		},
+		{
+			name: "operation security resolver feature",
+			json: `{"name":"resolver","restish_api_version":2,"hooks":["auth-resolver","auth"],"required_features":["auth.operation_security"]}`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/request/do.go
+++ b/internal/request/do.go
@@ -162,6 +162,10 @@ type Options struct {
 	// OnUnauthorized, when non-nil, is used by callers that want to retry once
 	// after a 401 with freshly acquired credentials.
 	OnUnauthorized func(*http.Request) error
+	// OnRetryRequest, when non-nil, refreshes request-bound authentication before
+	// each transport retry and same-origin redirect. Dynamic proof schemes use
+	// this to avoid replaying a signature bound to another request target.
+	OnRetryRequest func(*http.Request) error
 	// CacheDir, if non-empty, enables RFC 7234 response caching in that
 	// directory.  NoCache overrides this and skips the cache entirely.
 	CacheDir string
@@ -296,8 +300,16 @@ func Do(ctx context.Context, method, rawURL string, body io.Reader, opts Options
 		builtTransport = true
 	}
 	client := &http.Client{
-		Transport:     transport,
-		CheckRedirect: credentialStrippingRedirectPolicy,
+		Transport: transport,
+		CheckRedirect: func(redirected *http.Request, via []*http.Request) error {
+			if err := credentialStrippingRedirectPolicy(redirected, via); err != nil {
+				return err
+			}
+			if len(via) > 0 && SameOrigin(via[len(via)-1].URL, redirected.URL) && opts.OnRetryRequest != nil {
+				return opts.OnRetryRequest(redirected)
+			}
+			return nil
+		},
 	}
 
 	resp, err := doWithResponseTimeout(client, req, opts.Timeout, opts.HeaderTimeoutOnly, cancelRequest)
@@ -652,7 +664,7 @@ func BuildTransport(opts Options) http.RoundTripper {
 		if delay == 0 {
 			delay = time.Second
 		}
-		inner = retryTransport{inner: base, maxRetry: opts.Retry, retryUnsafe: opts.RetryUnsafe, baseDelay: delay, maxWait: opts.RetryMaxWait, logger: opts.Logger}
+		inner = retryTransport{inner: base, maxRetry: opts.Retry, retryUnsafe: opts.RetryUnsafe, baseDelay: delay, maxWait: opts.RetryMaxWait, logger: opts.Logger, onRetryRequest: opts.OnRetryRequest}
 	}
 
 	if opts.NoCache || opts.CacheDir == "" {

--- a/internal/request/retry.go
+++ b/internal/request/retry.go
@@ -17,12 +17,13 @@ const DefaultRetryMaxWait = 5 * time.Minute
 // and 5xx responses with exponential backoff + jitter.  4xx responses are
 // returned immediately without retrying.
 type retryTransport struct {
-	inner       http.RoundTripper
-	maxRetry    int
-	retryUnsafe bool
-	baseDelay   time.Duration
-	maxWait     time.Duration
-	logger      io.Writer
+	inner          http.RoundTripper
+	maxRetry       int
+	retryUnsafe    bool
+	baseDelay      time.Duration
+	maxWait        time.Duration
+	logger         io.Writer
+	onRetryRequest func(*http.Request) error
 }
 
 func (rt retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -67,6 +68,11 @@ func (rt retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 				}
 				req = req.Clone(req.Context())
 				req.Body = newBody
+			}
+			if rt.onRetryRequest != nil {
+				if retryErr := rt.onRetryRequest(req); retryErr != nil {
+					return nil, fmt.Errorf("refreshing authentication for retry: %w", retryErr)
+				}
 			}
 		}
 

--- a/internal/request/retry_test.go
+++ b/internal/request/retry_test.go
@@ -123,6 +123,47 @@ func TestRetryTransportRetries429AndLogsProgress(t *testing.T) {
 	}
 }
 
+func TestRetryTransportRefreshesRequestBoundAuthentication(t *testing.T) {
+	attempts := 0
+	refreshes := 0
+	rt := retryTransport{
+		baseDelay: time.Nanosecond,
+		maxRetry:  1,
+		onRetryRequest: func(req *http.Request) error {
+			refreshes++
+			req.Header.Set("DPoP", "proof-2")
+			return nil
+		},
+		inner: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			wantProof := "proof-1"
+			status := http.StatusInternalServerError
+			if attempts == 2 {
+				wantProof = "proof-2"
+				status = http.StatusOK
+			}
+			if got := req.Header.Get("DPoP"); got != wantProof {
+				t.Fatalf("attempt %d DPoP = %q, want %q", attempts, got, wantProof)
+			}
+			return &http.Response{StatusCode: status, Header: http.Header{}, Body: http.NoBody}, nil
+		}),
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://api.example.com/items", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("DPoP", "proof-1")
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("round trip: %v", err)
+	}
+	defer resp.Body.Close()
+	if refreshes != 1 {
+		t.Fatalf("auth refreshes = %d, want 1", refreshes)
+	}
+}
+
 func TestShouldRetryStatusUsesExplicitTransientSet(t *testing.T) {
 	retryable := []int{
 		http.StatusInternalServerError,

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -13,6 +13,7 @@ import (
 var HeaderNames = map[string]bool{
 	"Authorization":             true,
 	"Cookie":                    true,
+	"Dpop":                      true,
 	"Api-Key":                   true,
 	"Ocp-Apim-Subscription-Key": true,
 	"Proxy-Authorization":       true,
@@ -137,6 +138,7 @@ func RedactDiagnosticText(value string) string {
 		"authorization",
 		"proxy-authorization",
 		"cookie",
+		"dpop",
 		"set-cookie",
 		"x-api-key",
 		"x-api-token",
@@ -247,7 +249,7 @@ func redactDiagnosticAssignment(value, marker string) string {
 
 func diagnosticMarkerStopsAtSpace(marker string) bool {
 	switch marker {
-	case "authorization", "proxy-authorization", "cookie", "set-cookie", "x-api-key", "x-api-token", "x-auth-token":
+	case "authorization", "proxy-authorization", "cookie", "dpop", "set-cookie", "x-api-key", "x-api-token", "x-auth-token":
 		return false
 	default:
 		return true

--- a/internal/spec/openapi_helpers.go
+++ b/internal/spec/openapi_helpers.go
@@ -89,6 +89,10 @@ func ParamExtBool(p *v3.Parameter, key string) bool {
 	return extValue[bool](p.Extensions.GetOrZero(key))
 }
 
+func securitySchemeDPoPRequired(scheme *v3.SecurityScheme) bool {
+	return scheme != nil && scheme.Extensions != nil && extValue[bool](scheme.Extensions.GetOrZero("x-dpop-required"))
+}
+
 type decodableNode interface {
 	Decode(any) error
 }

--- a/internal/spec/operation.go
+++ b/internal/spec/operation.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -115,6 +116,18 @@ type CredentialRequirement struct {
 // CredentialAlternative is one AND-set within OpenAPI's OR-list security model.
 type CredentialAlternative []CredentialRequirement
 
+// ConditionalSecurityRule narrows an operation's standard security
+// alternatives when a concrete path parameter has the configured prefix.
+type ConditionalSecurityRule struct {
+	When         ConditionalSecurityPredicate `json:"when" cbor:"when" yaml:"when"`
+	Alternatives []int                        `json:"alternatives" cbor:"alternatives" yaml:"alternatives"`
+}
+
+type ConditionalSecurityPredicate struct {
+	PathParameter string `json:"pathParameter" cbor:"path_parameter" yaml:"pathParameter"`
+	Prefix        string `json:"prefix" cbor:"prefix" yaml:"prefix"`
+}
+
 // Operation is a single HTTP operation extracted from a spec, expressed in
 // format-neutral terms so command generators need not import libopenapi.
 type Operation struct {
@@ -143,6 +156,7 @@ type Operation struct {
 	// CredentialAlternatives is the OR-list of AND credential requirements
 	// derived from the effective OpenAPI security requirement.
 	CredentialAlternatives []CredentialAlternative
+	ConditionalSecurity    []ConditionalSecurityRule
 	// MCPIgnore is true when x-mcp-ignore is set.
 	MCPIgnore bool
 	// RequestMediaType is the deterministic preferred content type from
@@ -278,7 +292,10 @@ func (s *APISpec) buildOperations(opts OperationOptions) ([]Operation, []string,
 				}
 			}
 			fullPath := joinOperationPath(basePath, rawPath)
-			op := extractOperation(mo.Method, fullPath, pathParams, mo.Op, model.Model.Security, securitySchemes(model.Model.Components), openAPIJSONSchemaDialect(model.Model))
+			op, err := extractOperation(mo.Method, fullPath, pathParams, mo.Op, model.Model.Security, securitySchemes(model.Model.Components), openAPIJSONSchemaDialect(model.Model))
+			if err != nil {
+				return nil, nil, fmt.Errorf("extract %s %s: %w", mo.Method, rawPath, err)
+			}
 			op.OperationServer = operationServer
 			if op.XCLI.Ignore {
 				continue
@@ -302,7 +319,7 @@ func emitOperationWarnings(warnf func(format string, args ...any), warnings []st
 }
 
 // extractOperation converts a single libopenapi operation to the neutral form.
-func extractOperation(method, path string, pathParams []*v3.Parameter, op *v3.Operation, docSecurity []*base.SecurityRequirement, schemes map[string]*v3.SecurityScheme, schemaDialect string) Operation {
+func extractOperation(method, path string, pathParams []*v3.Parameter, op *v3.Operation, docSecurity []*base.SecurityRequirement, schemes map[string]*v3.SecurityScheme, schemaDialect string) (Operation, error) {
 	effectiveSecurity := docSecurity
 	if op.Security != nil {
 		effectiveSecurity = op.Security
@@ -333,6 +350,11 @@ func extractOperation(method, path string, pathParams []*v3.Parameter, op *v3.Op
 	o.Help = buildOperationHelp(op, o.RequestMediaType, schemaDialect)
 	o.RequestMultipartContentTypes = buildRequestMultipartContentTypes(op, o.RequestMediaType)
 	o.OptionalAuth, o.CredentialAlternatives = credentialAlternatives(effectiveSecurity, schemes)
+	conditionalSecurity, err := operationConditionalSecurity(op, path, len(o.CredentialAlternatives))
+	if err != nil {
+		return Operation{}, err
+	}
+	o.ConditionalSecurity = conditionalSecurity
 
 	merged := MergeParameters(pathParams, op.Parameters)
 	for _, p := range merged {
@@ -381,7 +403,43 @@ func extractOperation(method, path string, pathParams []*v3.Parameter, op *v3.Op
 			},
 		})
 	}
-	return o
+	return o, nil
+}
+
+func operationConditionalSecurity(op *v3.Operation, operationPath string, alternativeCount int) ([]ConditionalSecurityRule, error) {
+	if op.Extensions == nil || op.Extensions.GetOrZero("x-restish-security-alternatives") == nil {
+		return nil, nil
+	}
+	var rules []ConditionalSecurityRule
+	if err := op.Extensions.GetOrZero("x-restish-security-alternatives").Decode(&rules); err != nil {
+		return nil, fmt.Errorf("x-restish-security-alternatives: %w", err)
+	}
+	parameters := map[string]bool{}
+	for _, match := range regexp.MustCompile(`\{([^}]+)\}`).FindAllStringSubmatch(operationPath, -1) {
+		parameters[match[1]] = true
+	}
+	for ruleIndex, rule := range rules {
+		if !parameters[rule.When.PathParameter] {
+			return nil, fmt.Errorf("x-restish-security-alternatives[%d] references unknown path parameter %q", ruleIndex, rule.When.PathParameter)
+		}
+		if rule.When.Prefix == "" {
+			return nil, fmt.Errorf("x-restish-security-alternatives[%d] prefix must not be empty", ruleIndex)
+		}
+		if len(rule.Alternatives) == 0 {
+			return nil, fmt.Errorf("x-restish-security-alternatives[%d] must select at least one alternative", ruleIndex)
+		}
+		seen := map[int]bool{}
+		for _, index := range rule.Alternatives {
+			if index < 0 || index >= alternativeCount {
+				return nil, fmt.Errorf("x-restish-security-alternatives[%d] selects out-of-range alternative %d", ruleIndex, index)
+			}
+			if seen[index] {
+				return nil, fmt.Errorf("x-restish-security-alternatives[%d] repeats alternative %d", ruleIndex, index)
+			}
+			seen[index] = true
+		}
+	}
+	return rules, nil
 }
 
 func securitySchemes(components *v3.Components) map[string]*v3.SecurityScheme {

--- a/internal/spec/operation.go
+++ b/internal/spec/operation.go
@@ -470,8 +470,14 @@ func credentialRequirementKind(scheme *v3.SecurityScheme) string {
 	case "apiKey":
 		return "api-key"
 	case "oauth2":
+		if securitySchemeDPoPRequired(scheme) {
+			return "oauth2-dpop"
+		}
 		return "oauth2"
 	case "openIdConnect":
+		if securitySchemeDPoPRequired(scheme) {
+			return "oauth2-dpop"
+		}
 		return "openid"
 	case "mutualTLS":
 		return "mtls"
@@ -481,6 +487,8 @@ func credentialRequirementKind(scheme *v3.SecurityScheme) string {
 			return "http-basic"
 		case "bearer":
 			return "http-bearer"
+		case "dpop":
+			return "http-dpop"
 		default:
 			return "http"
 		}

--- a/internal/spec/operation_test.go
+++ b/internal/spec/operation_test.go
@@ -47,6 +47,51 @@ paths:
 	}
 }
 
+func TestOperationsExtractsAndValidatesConditionalSecurityAlternatives(t *testing.T) {
+	raw := `openapi: "3.1.0"
+info: {title: Test, version: "1.0.0"}
+components:
+  securitySchemes:
+    provider: {type: openIdConnect, openIdConnectUrl: https://issuer.example.com/.well-known/openid-configuration}
+paths:
+  /files/{path}:
+    put:
+      parameters:
+        - {name: path, in: path, required: true, schema: {type: string}}
+      security:
+        - provider: [contents:write]
+        - provider: [contents:write, workflows:write]
+      x-restish-security-alternatives:
+        - when: {pathParameter: path, prefix: .github/workflows/}
+          alternatives: [1]
+      responses:
+        "204": {description: Updated}`
+	loaded, err := load("application/yaml", []byte(raw), DefaultLoaders())
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	ops, err := loaded.Operations(OperationOptions{})
+	if err != nil {
+		t.Fatalf("operations: %v", err)
+	}
+	want := []ConditionalSecurityRule{{
+		When:         ConditionalSecurityPredicate{PathParameter: "path", Prefix: ".github/workflows/"},
+		Alternatives: []int{1},
+	}}
+	if !reflect.DeepEqual(ops[0].ConditionalSecurity, want) {
+		t.Fatalf("ConditionalSecurity = %#v, want %#v", ops[0].ConditionalSecurity, want)
+	}
+
+	invalid := strings.Replace(raw, "alternatives: [1]", "alternatives: [2]", 1)
+	loaded, err = load("application/yaml", []byte(invalid), DefaultLoaders())
+	if err != nil {
+		t.Fatalf("load invalid document: %v", err)
+	}
+	if _, err := loaded.Operations(OperationOptions{}); err == nil || !strings.Contains(err.Error(), "out-of-range alternative 2") {
+		t.Fatalf("expected conditional security validation error, got %v", err)
+	}
+}
+
 func TestOperationsExtractsPreferredResponseMediaType(t *testing.T) {
 	raw := `openapi: "3.1.0"
 info:

--- a/internal/spec/operation_test.go
+++ b/internal/spec/operation_test.go
@@ -464,6 +464,40 @@ paths:
 	}})
 }
 
+func TestOperationsRecognizesDPoPSecurityScheme(t *testing.T) {
+	raw := `openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0.0"
+components:
+  securitySchemes:
+    DPoP:
+      type: http
+      scheme: DPoP
+paths:
+  /wallet:
+    get:
+      operationId: getWallet
+      security:
+        - DPoP: []
+      responses:
+        "200":
+          description: OK`
+	loaded, err := load("application/yaml", []byte(raw), DefaultLoaders())
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	ops, err := loaded.Operations(OperationOptions{BaseURL: "https://api.example.com"})
+	if err != nil {
+		t.Fatalf("operations: %v", err)
+	}
+
+	requireCredential(t, operationByID(t, ops, "getWallet"), [][]CredentialRequirement{{
+		{ID: "DPoP", Ref: "#/components/securitySchemes/DPoP", Kind: "http-dpop", Source: "openapi"},
+	}})
+}
+
 func TestOperationsUsesConfiguredServerVariables(t *testing.T) {
 	raw := `openapi: "3.1.0"
 info:

--- a/internal/spec/xcliconfig.go
+++ b/internal/spec/xcliconfig.go
@@ -244,6 +244,15 @@ func referencedFallbackSecuritySchemeNames(model v3high.Document) []string {
 func SchemeToXCLIAuth(scheme *v3high.SecurityScheme, params map[string]string) *XCLIAuth {
 	p := map[string]string{}
 	var authType string
+	if securitySchemeDPoPRequired(scheme) && (scheme.Type == "oauth2" || scheme.Type == "openIdConnect") {
+		authType = "dpop"
+		p["source"] = ""
+		p["reference"] = ""
+		for k, v := range params {
+			p[k] = v
+		}
+		return &XCLIAuth{Type: authType, Params: p}
+	}
 
 	switch scheme.Type {
 	case "apiKey":
@@ -255,7 +264,7 @@ func SchemeToXCLIAuth(scheme *v3high.SecurityScheme, params map[string]string) *
 		p["name"] = scheme.Name
 		p["value"] = ""
 	case "http":
-		switch scheme.Scheme {
+		switch strings.ToLower(scheme.Scheme) {
 		case "basic":
 			authType = "http-basic"
 			p["username"] = ""
@@ -263,6 +272,10 @@ func SchemeToXCLIAuth(scheme *v3high.SecurityScheme, params map[string]string) *
 		case "bearer":
 			authType = "bearer"
 			p["token"] = ""
+		case "dpop":
+			authType = "dpop"
+			p["source"] = ""
+			p["reference"] = ""
 		default:
 			return nil
 		}

--- a/internal/spec/xcliconfig_test.go
+++ b/internal/spec/xcliconfig_test.go
@@ -184,6 +184,34 @@ components:
 	}
 }
 
+func TestSchemeToXCLIAuth_HTTPNamesAreCaseInsensitive(t *testing.T) {
+	raw := `
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0.0"
+paths: {}
+components:
+  securitySchemes:
+    bearer:
+      type: http
+      scheme: Bearer
+    proof:
+      type: http
+      scheme: DPoP`
+	doc := loadDoc(t, raw)
+	model, err := doc.V3Model()
+	if err != nil || model == nil {
+		t.Fatalf("BuildV3Model: %v", err)
+	}
+	for name, want := range map[string]string{"bearer": "bearer", "proof": "dpop"} {
+		auth := SchemeToXCLIAuth(model.Model.Components.SecuritySchemes.GetOrZero(name), nil)
+		if auth == nil || auth.Type != want {
+			t.Errorf("%s auth = %#v, want %s", name, auth, want)
+		}
+	}
+}
+
 func TestSchemeToXCLIAuth_OAuth2AuthCode(t *testing.T) {
 	raw := `
 openapi: "3.1.0"

--- a/plugin/manifest.go
+++ b/plugin/manifest.go
@@ -35,6 +35,15 @@ const (
 	// FeatureRequestFinalBody means auth and request-middleware hooks may
 	// receive the final request body bytes when Restish has them.
 	FeatureRequestFinalBody = "request.final_body"
+	// FeatureAuthOperationSecurity means auth resolver and auth hooks receive
+	// the exact OpenAPI operation security alternative selected by Restish.
+	FeatureAuthOperationSecurity = "auth.operation_security"
+	// FeatureDPoPCredentialSource means the host supports provider-neutral,
+	// proof-bound DPoP acquisition through credential-source hooks.
+	FeatureDPoPCredentialSource = "auth.dpop_credential_source"
+	// FeatureDPoPOperationScopes means credential-source hooks receive the
+	// exact OpenAPI operation scopes required by the current request.
+	FeatureDPoPOperationScopes = "auth.dpop_operation_scopes"
 )
 
 // Manifest is the metadata a plugin reports when called with

--- a/plugin/messages.go
+++ b/plugin/messages.go
@@ -1,5 +1,7 @@
 package plugin
 
+import "time"
+
 // Message type constants for the command plugin protocol.
 // Use these instead of bare strings to avoid typos; a mismatched type string
 // causes the host or plugin to silently ignore the message.
@@ -398,16 +400,94 @@ type HookRequestHeaderUpdate struct {
 
 // AuthHookInput is sent to plugins registered for the "auth" hook.
 type AuthHookInput struct {
-	Type    string            `cbor:"type" json:"type"`
-	API     string            `cbor:"api" json:"api"`
-	Profile string            `cbor:"profile" json:"profile"`
-	Params  map[string]string `cbor:"params" json:"params"`
-	Request HookRequest       `cbor:"request" json:"request"`
+	Type         string            `cbor:"type" json:"type"`
+	API          string            `cbor:"api" json:"api"`
+	Profile      string            `cbor:"profile" json:"profile"`
+	Params       map[string]string `cbor:"params" json:"params"`
+	Requirements []AuthRequirement `cbor:"requirements,omitempty" json:"requirements,omitempty"`
+	Request      HookRequest       `cbor:"request" json:"request"`
 }
 
 // AuthHookOutput is the reply from an "auth" hook plugin.
 type AuthHookOutput struct {
 	Request *HookRequestHeaderUpdate `cbor:"request,omitempty" json:"request,omitempty"`
+}
+
+// AuthRequirement describes one OpenAPI security scheme in an AND
+// alternative. Needs contains the scopes required by the operation.
+type AuthRequirement struct {
+	ID         string   `cbor:"id" json:"id"`
+	Ref        string   `cbor:"ref,omitempty" json:"ref,omitempty"`
+	Kind       string   `cbor:"kind" json:"kind"`
+	Needs      []string `cbor:"needs,omitempty" json:"needs,omitempty"`
+	In         string   `cbor:"in,omitempty" json:"in,omitempty"`
+	Name       string   `cbor:"name,omitempty" json:"name,omitempty"`
+	Source     string   `cbor:"source,omitempty" json:"source,omitempty"`
+	External   bool     `cbor:"external,omitempty" json:"external,omitempty"`
+	Undeclared bool     `cbor:"undeclared,omitempty" json:"undeclared,omitempty"`
+	Deprecated bool     `cbor:"deprecated,omitempty" json:"deprecated,omitempty"`
+}
+
+// AuthResolverInput asks an auth plugin whether it can satisfy one complete
+// OpenAPI security alternative for the final request target.
+type AuthResolverInput struct {
+	Type         string            `cbor:"type" json:"type"`
+	API          string            `cbor:"api" json:"api"`
+	Profile      string            `cbor:"profile" json:"profile"`
+	Requirements []AuthRequirement `cbor:"requirements" json:"requirements"`
+	Request      HookRequest       `cbor:"request" json:"request"`
+}
+
+// AuthResolverOutput is the reply from an "auth-resolver" hook plugin.
+type AuthResolverOutput struct {
+	Handled bool `cbor:"handled" json:"handled"`
+}
+
+// CredentialSourceInput is sent to a plugin registered for the
+// "credential-source" hook. Describe resolves public acquisition metadata;
+// issue redeems the same opaque reference with a proof created by Restish.
+type CredentialSourceInput struct {
+	Type      string   `cbor:"type" json:"type"`
+	Action    string   `cbor:"action" json:"action"`
+	API       string   `cbor:"api" json:"api"`
+	Profile   string   `cbor:"profile" json:"profile"`
+	Reference string   `cbor:"reference" json:"reference"`
+	Scopes    []string `cbor:"scopes,omitempty" json:"scopes,omitempty"`
+	Proof     string   `cbor:"proof,omitempty" json:"proof,omitempty"`
+}
+
+// CredentialSourceDescription supplies the public values Restish binds into
+// a DPoP proof before asking the source to issue a credential.
+type CredentialSourceDescription struct {
+	ProofMethod string   `cbor:"proof_method" json:"proofMethod"`
+	ProofURI    string   `cbor:"proof_uri" json:"proofUri"`
+	Resource    string   `cbor:"resource" json:"resource"`
+	Scopes      []string `cbor:"scopes,omitempty" json:"scopes,omitempty"`
+}
+
+// CredentialSourceCredential is the short-lived credential returned only
+// over the bounded plugin channel. Hosts must never print it.
+type CredentialSourceCredential struct {
+	AccessToken string    `cbor:"access_token" json:"accessToken"`
+	TokenType   string    `cbor:"token_type" json:"tokenType"`
+	ExpiresAt   time.Time `cbor:"expires_at" json:"expiresAt"`
+	Resource    string    `cbor:"resource" json:"resource"`
+	Scopes      []string  `cbor:"scopes,omitempty" json:"scopes,omitempty"`
+	Nonce       string    `cbor:"nonce,omitempty" json:"nonce,omitempty"`
+}
+
+// CredentialSourceChallenge asks Restish to create a fresh proof for the
+// described endpoint. Nonce values remain opaque to plugins and Restish.
+type CredentialSourceChallenge struct {
+	Type  string `cbor:"type" json:"type"`
+	Nonce string `cbor:"nonce" json:"nonce"`
+}
+
+// CredentialSourceOutput is the reply from a credential-source hook.
+type CredentialSourceOutput struct {
+	Description *CredentialSourceDescription `cbor:"description,omitempty" json:"description,omitempty"`
+	Credential  *CredentialSourceCredential  `cbor:"credential,omitempty" json:"credential,omitempty"`
+	Challenge   *CredentialSourceChallenge   `cbor:"challenge,omitempty" json:"challenge,omitempty"`
 }
 
 // RequestMiddlewareInput is sent to plugins registered for the

--- a/site/content/en/docs/guides/authentication.md
+++ b/site/content/en/docs/guides/authentication.md
@@ -152,6 +152,26 @@ declared requirements.
 These commands use placeholder operation names because the public example API
 does not expose a multi-scheme partner-auth fixture.
 
+## DPoP Credential Sources
+
+When an OpenAPI security scheme uses `type: http` with `scheme: DPoP`, or an
+OAuth 2.0/OpenID Connect scheme declares `x-dpop-required: true`, Restish can
+own the proof key and token lifecycle while an installed plugin supplies
+provider-specific token acquisition. First obtain an opaque source reference
+from that provider, then bind it to the exact OpenAPI credential ID:
+
+```bash
+restish api auth add myapi ResourceDPoP \
+  --source provider-plugin \
+  --reference https://identity.example/resources/123
+```
+
+The source and reference are configuration, not access tokens. Restish creates
+and stores the P-256 private key, asks the source for short-lived tokens, signs
+each target request, renews expired credentials, and forces one renewal after
+a `401`. `api auth logout` deletes the cached token and key; `api auth remove`
+removes the local OpenAPI credential binding.
+
 ## Inspect Auth Material
 
 For configured API auth, inspect the computed auth material without making the
@@ -176,6 +196,13 @@ shareable output. `--redact` is safe to include even when no secrets are
 configured, which makes it a good default for bug reports. Use
 `api auth get` when a script or curl command needs a single auth header or
 query-string fragment.
+
+When an installed `auth-resolver` owns the credential, inspection does not run
+the plugin without a final request target. It reports how many secured
+operations will evaluate a resolver at request time and labels the affected
+requirements as unconfigured rather than missing. Invoke the generated
+operation to determine whether the resolver can satisfy its exact URL and
+security requirements.
 
 For curl, pass a header fragment to `-H` or append a query fragment to the URL:
 

--- a/site/content/en/docs/reference/api-management.md
+++ b/site/content/en/docs/reference/api-management.md
@@ -271,7 +271,7 @@ Examples:
 
 Subcommands:
 
-**`restish api auth add`**: Add an empty credential binding to an API profile
+**`restish api auth add`**: Add or configure a credential binding on an API profile
 
 **`restish api auth get`**: Print curl-friendly auth material for an API profile
 
@@ -284,7 +284,7 @@ Subcommands:
 
 ### `restish api auth add`
 
-Add an empty credential binding to an API profile
+Add or configure a credential binding on an API profile
 
 Add or initialize a credential binding for an API profile.
 
@@ -293,14 +293,30 @@ Use this after `api auth inspect` reports a missing credential ID. When cached O
 Usage:
 
 ```text
-restish api auth add <api> <credential-id>
+restish api auth add <api> <credential-id> [flags]
 ```
 
 Examples:
 
 ```bash
   restish api auth add demo PartnerKey
+  restish api auth add demo ResourceDPoP --source identity --reference https://identity.example/resources/123
 ```
+
+Flags:
+
+**`--reference`**
+
+Type: `string`; default: none
+
+opaque credential-source reference for a DPoP credential
+
+**`--source`**
+
+Type: `string`; default: none
+
+credential-source plugin for a DPoP credential
+
 
 
 ### `restish api auth remove`
@@ -535,6 +551,11 @@ non-Authorization credentials such as API-key headers and query params. Use
 `get` when another tool needs one curl-friendly auth fragment. Use
 `--operation` when an operation's OpenAPI security policy affects which
 credential applies.
+
+If a runtime auth resolver applies and no static credential is configured,
+`inspect` reports resolver evaluation as deferred until the final request is
+built. Deferred operations are not counted as statically callable, and Restish
+offers static `auth add` only as a generic fallback if the resolver declines.
 
 ## Related Pages
 

--- a/site/content/en/docs/reference/openapi-cli-integration.md
+++ b/site/content/en/docs/reference/openapi-cli-integration.md
@@ -412,14 +412,32 @@ type because a remote spec must not cause a local executable to run.
 Generated commands honor operation-level security:
 
 - `security: []` is public and sends no configured auth.
+- If configured credentials cannot satisfy an authenticated operation, an
+installed `auth-resolver` plugin may claim one complete security alternative.
+When Restish retries a request authenticated by a resolver, it invokes that
+resolver's auth hook again so request-bound proofs are fresh for every attempt.
+  Restish passes its exact scopes and final request target to the selected auth
+  plugin; multiple claims fail instead of selecting one implicitly.
+  `api auth inspect` reports this selection as deferred until request time; it
+  does not invoke the resolver or recommend a specific static binding solely
+  because no configured credential exists.
 - A single effective requirement can use profile-level `auth` for compatibility.
 - Multiple alternatives or combined requirements use
   `profiles.<name>.credentials.<credential-id>` bindings.
+
 - `mutualTLS` requirements are satisfied by TLS settings, not prompt-backed
   credentials. Use `--rsh-client-cert` with `--rsh-client-key`, profile
   `client_cert`/`client_key`, or a profile/flag TLS signer.
 - `--rsh-auth PartnerKey` or `--rsh-auth UserOAuth+PartnerKey` selects
   one allowed alternative for an operation.
+
+OAuth 2.0 and OpenID Connect security schemes with `x-dpop-required: true`, as
+well as HTTP schemes named `DPoP`, resolve to Restish's native `dpop` auth type.
+Configure those named bindings with `api auth add --source --reference` so the
+client owns the proof key while the selected credential-source plugin performs
+provider-specific token acquisition. Restish forwards only the scopes required
+by the matched operation; dynamic DPoP bindings are evaluated per request and
+are not reported as statically callable by `api auth inspect`.
 
 OpenAPI scope and role arrays are matched against credential `satisfies` values.
 When a required binding is missing, Restish fails before sending the request.

--- a/site/content/en/docs/reference/openapi-cli-integration.md
+++ b/site/content/en/docs/reference/openapi-cli-integration.md
@@ -442,6 +442,25 @@ are not reported as statically callable by `api auth inspect`.
 OpenAPI scope and role arrays are matched against credential `satisfies` values.
 When a required binding is missing, Restish fails before sending the request.
 
+When a concrete path parameter determines which standard security alternative
+applies, use `x-restish-security-alternatives` on the operation:
+
+```yaml
+security:
+  - ProviderAuth: [contents:write]
+  - ProviderAuth: [contents:write, workflows:write]
+x-restish-security-alternatives:
+  - when:
+      pathParameter: path
+      prefix: .github/workflows/
+    alternatives: [1]
+```
+
+The zero-based indexes refer to the operation's standard `security` array. A
+matching rule narrows selection to those alternatives after Restish knows the
+concrete request path. The extension cannot add authority that is absent from
+standard OpenAPI security, and malformed rules fail API synchronization.
+
 Never put secrets in the OpenAPI document. Use prompts, environment references,
 or external tools.
 

--- a/site/content/en/docs/reference/plugin-messages.md
+++ b/site/content/en/docs/reference/plugin-messages.md
@@ -835,6 +835,10 @@ CBOR: `profile`; JSON: `profile`; type: `string`; required: yes
 
 CBOR: `params`; JSON: `params`; type: `map[string]string`; required: yes
 
+**`Requirements`**
+
+CBOR: `requirements`; JSON: `requirements`; type: `[]AuthRequirement`; required: no
+
 **`Request`**
 
 CBOR: `request`; JSON: `request`; type: `HookRequest`; required: yes


### PR DESCRIPTION
## Summary

- add operation-aware DPoP credential sources and request-bound proof handling
- preserve OpenAPI OR alternatives and AND requirements through plugin resolution
- add provider-neutral `x-restish-security-alternatives` path predicates
- apply conditional alternatives to generated commands and generic URL requests, including slash-containing terminal path parameters

## Why

OpenAPI cannot express a security requirement that depends on a concrete path-parameter value. Transparent providers such as GitHub need this to request `contents:write` for ordinary files and `contents:write` plus `workflows:write` for workflow files before the request is sent.

## Coordinated changes

- Realmroot generic Connection Event API: https://github.com/realmroot/realmroot/pull/167
- GitHub adapter permissions/webhooks: https://github.com/realmroot/adapters/pull/9

## Validation

- `CGO_ENABLED=1 go test ./...`
- `CGO_ENABLED=1 go test -tags=integration ./...`
- `CGO_ENABLED=1 go test -race ./...`
- built all five CLI binaries
- `go run ./cmd/restish-docgen --check`
- documentation link and example checks
- social-image generation

The Hugo render could not be run locally because this machine does not have the `hugo` executable.

## Review environment acceptance

1. Build `./cmd/restish` from this branch and build the `restish-realmroot` plugin from Realmroot PR #167.
2. Install the plugin and connect a GitHub adapter OpenAPI profile backed by a GitHub App installation that grants `contents:write` and `workflows:write`.
3. Run a generic `PUT` to `/repos/{owner}/{repo}/contents/README.md`; inspect the authorization flow and confirm it requests only `contents:write`.
4. Run the same generic `PUT` to `/repos/{owner}/{repo}/contents/.github/workflows/release.yml`; confirm Restish selects the conjunctive alternative and requests both native scopes before execution.
5. Repeat the workflow-file journey through the generated operation command and confirm the same scope set.
6. Confirm ordinary slash-containing content paths still match the generated OpenAPI operation for generic requests.

No deployment or merge is included in this PR.
