### PR TITLE
fix(spec): validate top-level OpenAPI versions

### DIFF
--- a/internal/spec/openapi.go
+++ b/internal/spec/openapi.go
@@ -3,6 +3,7 @@ package spec
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -27,7 +28,7 @@ func (OpenAPILoader) Priority() int { return 10 }
 
 // Detect returns true when the content type or body look like an OpenAPI spec.
 // It accepts JSON, YAML, text-ish raw files, and the official OpenAPI MIME
-// types, then confirms by sniffing for an "openapi:" / `"openapi"` key.
+// types, then confirms generic documents have a top-level OpenAPI version.
 func (OpenAPILoader) Detect(contentType string, body []byte) bool {
 	ct := strings.ToLower(contentType)
 	if strings.Contains(ct, "openapi") {
@@ -41,15 +42,7 @@ func (OpenAPILoader) Detect(contentType string, body []byte) bool {
 		return false
 	}
 
-	// Body sniff: look for the "openapi" field. Some generated specs write
-	// the top-level openapi field late in the document, so generic JSON/YAML
-	// cannot rely on a tiny prefix sniff.
-	sniff := body
-	low := bytes.ToLower(sniff)
-	return bytes.Contains(low, []byte(`"openapi"`)) ||
-		bytes.Contains(low, []byte("openapi:")) ||
-		bytes.Contains(low, []byte(`"swagger"`)) ||
-		bytes.Contains(low, []byte("swagger:"))
+	return isOpenAPI3Document(body) || isSwagger2Document(body)
 }
 
 // Load parses body as an OpenAPI 3.x document.
@@ -143,23 +136,78 @@ func shouldIgnoreDescriptionRefPath(path []string) bool {
 }
 
 func isSwagger2Document(body []byte) bool {
+	version, ok := topLevelDocumentVersion(body, "swagger")
+	return ok && version == "2.0"
+}
+
+func isOpenAPI3Document(body []byte) bool {
+	version, ok := topLevelDocumentVersion(body, "openapi")
+	if !ok {
+		return false
+	}
+	parts := strings.Split(version, ".")
+	if len(parts) != 3 || parts[0] != "3" {
+		return false
+	}
+	for _, part := range parts[1:] {
+		if part == "" {
+			return false
+		}
+		if _, err := strconv.ParseUint(part, 10, 64); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+func topLevelDocumentVersion(body []byte, key string) (string, bool) {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) > 0 && trimmed[0] == '{' {
+		return topLevelJSONDocumentVersion(trimmed, key)
+	}
 	var doc yaml.Node
 	if err := yaml.Unmarshal(body, &doc); err != nil {
-		return false
+		return "", false
 	}
 	root := &doc
 	if doc.Kind == yaml.DocumentNode && len(doc.Content) > 0 {
 		root = doc.Content[0]
 	}
 	if root.Kind != yaml.MappingNode {
-		return false
+		return "", false
 	}
 	for i := 0; i+1 < len(root.Content); i += 2 {
-		if root.Content[i].Value == "swagger" && strings.TrimSpace(root.Content[i+1].Value) == "2.0" {
-			return true
+		if root.Content[i].Value == key && root.Content[i+1].Kind == yaml.ScalarNode {
+			return strings.TrimSpace(root.Content[i+1].Value), true
 		}
 	}
-	return false
+	return "", false
+}
+
+func topLevelJSONDocumentVersion(body []byte, key string) (string, bool) {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	token, err := decoder.Token()
+	if err != nil || token != json.Delim('{') {
+		return "", false
+	}
+	for decoder.More() {
+		name, err := decoder.Token()
+		if err != nil {
+			return "", false
+		}
+		if name == key {
+			var version string
+			if err := decoder.Decode(&version); err != nil {
+				return "", false
+			}
+			return strings.TrimSpace(version), true
+		}
+		var value json.RawMessage
+		if err := decoder.Decode(&value); err != nil {
+			return "", false
+		}
+	}
+	return "", false
 }
 
 func openAPIConfig(opts LoadOptions) *datamodel.DocumentConfiguration {

--- a/internal/spec/openapi.go
+++ b/internal/spec/openapi.go
@@ -167,7 +167,7 @@ func topLevelDocumentVersion(body []byte, key string) (string, bool) {
 	}
 	var doc yaml.Node
 	if err := yaml.Unmarshal(body, &doc); err != nil {
-		return "", false
+		return topLevelYAMLDocumentVersion(body, key)
 	}
 	root := &doc
 	if doc.Kind == yaml.DocumentNode && len(doc.Content) > 0 {
@@ -180,6 +180,22 @@ func topLevelDocumentVersion(body []byte, key string) (string, bool) {
 		if root.Content[i].Value == key && root.Content[i+1].Kind == yaml.ScalarNode {
 			return strings.TrimSpace(root.Content[i+1].Value), true
 		}
+	}
+	return "", false
+}
+
+func topLevelYAMLDocumentVersion(body []byte, key string) (string, bool) {
+	prefix := key + ":"
+	for _, line := range strings.Split(string(body), "\n") {
+		if !strings.HasPrefix(line, prefix) {
+			continue
+		}
+		var field map[string]string
+		if err := yaml.Unmarshal([]byte(line), &field); err != nil {
+			return "", false
+		}
+		version, ok := field[key]
+		return strings.TrimSpace(version), ok
 	}
 	return "", false
 }

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -115,6 +115,14 @@ func TestOpenAPILoader_Detect_MalformedDocumentWithDeclaredVersion(t *testing.T)
 	}
 }
 
+func TestOpenAPILoader_Detect_MalformedYAMLWithDeclaredVersion(t *testing.T) {
+	l := OpenAPILoader{}
+	body := []byte("openapi: 3.1.0\ninfo: [")
+	if !l.Detect("application/yaml", body) {
+		t.Error("should detect a declared OpenAPI version so loading reports the malformed YAML document")
+	}
+}
+
 func TestOpenAPILoader_Detect_WrongContentType(t *testing.T) {
 	l := OpenAPILoader{}
 	// image/png with openapi body: content-type mismatch should reject.

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -67,6 +67,54 @@ func TestOpenAPILoader_Detect_NotOpenAPI(t *testing.T) {
 	}
 }
 
+func TestOpenAPILoader_Detect_RejectsOpenAPIURLMetadata(t *testing.T) {
+	l := OpenAPILoader{}
+	body := []byte(`{"name":"Example API","openapi":"https://api.example.com/openapi.json"}`)
+	if l.Detect("application/json", body) {
+		t.Error("should not detect service metadata containing an OpenAPI URL")
+	}
+}
+
+func TestOpenAPILoader_Detect_RejectsNestedOpenAPIVersion(t *testing.T) {
+	l := OpenAPILoader{}
+	body := []byte(`{"metadata":{"openapi":"3.1.0"}}`)
+	if l.Detect("application/json", body) {
+		t.Error("should not detect a nested OpenAPI version")
+	}
+}
+
+func TestOpenAPILoader_Detect_RejectsInvalidOpenAPIVersions(t *testing.T) {
+	l := OpenAPILoader{}
+	for _, body := range []string{
+		`{"openapi":"3"}`,
+		`{"openapi":"3.1"}`,
+		`{"openapi":"3.1.x"}`,
+		`{"openapi":"4.0.0"}`,
+		`["openapi", "3.1.0"]`,
+		`openapi: [3, 1, 0]`,
+		`{`,
+	} {
+		if l.Detect("application/json", []byte(body)) {
+			t.Errorf("should not detect invalid OpenAPI document %q", body)
+		}
+	}
+}
+
+func TestOpenAPILoader_Detect_Swagger2ForUnsupportedVersionError(t *testing.T) {
+	l := OpenAPILoader{}
+	if !l.Detect("application/json", []byte(`{"swagger":"2.0","paths":{}}`)) {
+		t.Error("should detect Swagger 2 so loading can return its unsupported-version error")
+	}
+}
+
+func TestOpenAPILoader_Detect_MalformedDocumentWithDeclaredVersion(t *testing.T) {
+	l := OpenAPILoader{}
+	body := []byte(`{"openapi":"3.1.0","info":`)
+	if !l.Detect("application/json", body) {
+		t.Error("should detect a declared OpenAPI version so loading reports the malformed document")
+	}
+}
+
 func TestOpenAPILoader_Detect_WrongContentType(t *testing.T) {
 	l := OpenAPILoader{}
 	// image/png with openapi body: content-type mismatch should reject.


### PR DESCRIPTION
## What changed

- require generic JSON/YAML candidates to declare a top-level OpenAPI 3.x version before selecting the built-in loader
- keep official OpenAPI media types and Swagger 2 detection behavior intact
- preserve malformed-document errors when a JSON document declares its version before later invalid content
- add regression coverage for service metadata containing an OpenAPI document URL and nested `openapi` fields

## Why

Spec discovery probes the API root, advertised `service-desc` links, and well-known OpenAPI paths concurrently. A service root representation such as:

```json
{"name":"Example API","openapi":"https://api.example.com/openapi.json"}
```

was accepted as an OpenAPI document because detection searched for the word `openapi` anywhere in a generic JSON/YAML body. If that root probe completed first, Restish cached an empty operation set instead of using the advertised OpenAPI document.

The OpenAPI Object requires `openapi` to be a top-level specification version. Validating that boundary rejects service metadata while leaving the existing discovery probes to select the real document.

## Impact

Generated commands are now stable for APIs whose root metadata publishes an OpenAPI URL under an `openapi` field. Existing valid OpenAPI 3.x documents, including documents with a late top-level version field, continue to load.

## Verification

- `go test ./internal/spec -count=1`
- `go test ./internal/cli -count=1`
- `go test -race ./internal/spec ./internal/cli`
- `go vet ./internal/spec ./internal/cli`
- `go test ./...` passes all packages except the pre-existing local `cmd/restish-pkcs11` build failure caused by unavailable PKCS#11/cgo symbols in `github.com/ThalesIgnite/crypto11`
