### PR TITLE
docs: list third-party plugins

### DIFF
--- a/site/content/en/docs/plugins/_index.md
+++ b/site/content/en/docs/plugins/_index.md
@@ -16,7 +16,7 @@ keeping HTTP execution and output behavior anchored in the host CLI.
 Start here when you want to use an existing plugin:
 
 - [Install and Use Plugins](./install-and-use/) for installation, listing, removal, and debugging.
-- [Built-In Example Plugins](./example-plugins/) to find first-party plugin binaries.
+- [Example Plugins](./example-plugins/) to find first-party references and independently maintained plugins.
 - [TLS Signer Plugins](./tls-signer-plugins/) for hardware-backed or external mTLS signing.
 - [Bulk Management](/docs/plugins/bulk-management/) for `restish-bulk`.
 - [MCP](/docs/plugins/mcp/) for `restish-mcp`.

--- a/site/content/en/docs/plugins/example-plugins.md
+++ b/site/content/en/docs/plugins/example-plugins.md
@@ -34,6 +34,7 @@ source and installation instructions before running them.
 | Plugin | Repository | Use it for |
 | --- | --- | --- |
 | `restish-arazzo` | [`natalie-o-perret/restish-plugin-arazzo`](https://github.com/natalie-o-perret/restish-plugin-arazzo) | Run [Arazzo 1.0.x](https://spec.openapis.org/arazzo/v1.0.1.html) workflows across configured Restish APIs. |
+| `restish-progress` | [`natalie-o-perret/restish-plugin-progress`](https://github.com/natalie-o-perret/restish-plugin-progress) | Render SSE and NDJSON progress events as terminal progress bars. |
 
 Restish validates plugin protocol compatibility, but does not verify publishers
 or audit third-party behavior.

--- a/site/content/en/docs/plugins/example-plugins.md
+++ b/site/content/en/docs/plugins/example-plugins.md
@@ -33,7 +33,7 @@ source and installation instructions before running them.
 
 | Plugin | Repository | Use it for |
 | --- | --- | --- |
-| `restish-workflow` | [`natalie-o-perret/restish-plugin-arazzo`](https://github.com/natalie-o-perret/restish-plugin-arazzo) | Run Arazzo 1.0.x workflows across configured Restish APIs. |
+| `restish-arazzo` | [`natalie-o-perret/restish-plugin-arazzo`](https://github.com/natalie-o-perret/restish-plugin-arazzo) | Run [Arazzo 1.0.x](https://spec.openapis.org/arazzo/v1.0.1.html) workflows across configured Restish APIs. |
 
 Restish validates plugin protocol compatibility, but does not verify publishers
 or audit third-party behavior.

--- a/site/content/en/docs/plugins/example-plugins.md
+++ b/site/content/en/docs/plugins/example-plugins.md
@@ -33,7 +33,7 @@ source and installation instructions before running them.
 
 | Plugin | Repository | Use it for |
 | --- | --- | --- |
-| `restish-workflow` | [`natalie-o-perret/restish-plugin-workflow`](https://github.com/natalie-o-perret/restish-plugin-workflow) | Run Arazzo 1.0.x workflows across configured Restish APIs. |
+| `restish-workflow` | [`natalie-o-perret/restish-plugin-arazzo`](https://github.com/natalie-o-perret/restish-plugin-arazzo) | Run Arazzo 1.0.x workflows across configured Restish APIs. |
 
 Restish validates plugin protocol compatibility, but does not verify publishers
 or audit third-party behavior.

--- a/site/content/en/docs/plugins/example-plugins.md
+++ b/site/content/en/docs/plugins/example-plugins.md
@@ -1,8 +1,8 @@
 ---
-title: Built-In Example Plugins
+title: Example Plugins
 linkTitle: Example Plugins
 weight: 20
-description: Map first-party plugin binaries and fixtures to user and author goals.
+description: Find first-party reference implementations and independently maintained Restish plugins.
 ---
 
 The repository includes plugin binaries that are both useful tools and reference
@@ -13,7 +13,7 @@ If you are only trying to install and run a plugin, start with
 [Install and Use Plugins](../install-and-use/). If you are writing one, read
 the relevant author guide after finding the closest example here.
 
-## Operator-Facing Plugins
+## First-Party Plugins
 
 | Plugin | Path | Use it for |
 | --- | --- | --- |
@@ -25,6 +25,18 @@ the relevant author guide after finding the closest example here.
 These binaries are built like normal Go commands. Once installed where Restish
 can discover them, they participate in the same plugin lifecycle as third-party
 plugins.
+
+## Third-Party Plugins
+
+Third-party plugins are maintained outside the Restish project. Review their
+source and installation instructions before running them.
+
+| Plugin | Repository | Use it for |
+| --- | --- | --- |
+| `restish-workflow` | [`natalie-o-perret/restish-plugin-workflow`](https://github.com/natalie-o-perret/restish-plugin-workflow) | Run Arazzo 1.0.x workflows across configured Restish APIs. |
+
+Restish validates plugin protocol compatibility, but does not verify publishers
+or audit third-party behavior.
 
 ## Author Fixtures
 

--- a/site/content/en/docs/plugins/quickstart.md
+++ b/site/content/en/docs/plugins/quickstart.md
@@ -109,8 +109,8 @@ flags.
 | Expose APIs to another protocol | `cmd/restish-mcp/main.go` | [Command Plugins](../command-plugins/) and [MCP](../mcp/) |
 | Sign mTLS with external key material | `cmd/restish-pkcs11/main.go` | [TLS Signer Plugins](../tls-signer-plugins/) |
 
-Use [Built-In Example Plugins](../example-plugins/) as the map from binary to
-source path.
+Use the first-party section of [Example Plugins](../example-plugins/) as the map
+from binary to source path.
 
 ## Compatibility
 
@@ -127,7 +127,7 @@ read the wire protocol reference.
 
 - [Hook Plugins](../hook-plugins/)
 - [Command Plugins](../command-plugins/)
-- [Built-In Example Plugins](../example-plugins/)
+- [Example Plugins](../example-plugins/)
 - [Plugin Manifest](/docs/reference/plugin-manifest/)
 - [Plugin Messages](/docs/reference/plugin-messages/)
 - [Plugin Command](/docs/reference/plugin-command/)


### PR DESCRIPTION
## Summary

- separates first-party references from independently maintained plugins
- lists `restish-arazzo` and `restish-progress` with their external repositories and purposes
- updates related plugin docs to use the broader Example Plugins title

Closes #420

---

> [!NOTE]
> AI assistance: documentation, PR description.
