### PR TITLE
feat(plugin): add host-owned selection

### DIFF
--- a/cmd/restish-docgen/main.go
+++ b/cmd/restish-docgen/main.go
@@ -720,7 +720,7 @@ func renderMessageSchemaRegion(root string) (string, error) {
 		out.WriteString(fmt.Sprintf("| `%s` | `%s` |\n", c.Name, c.Value))
 	}
 	for _, group := range [][]string{
-		{"InitMsg", "HTTPRequestMsg", "HTTPResponseMsg", "APISpecMsg", "APISpecResponseMsg", "APIOperation", "APIParam", "ListAPIsMsg", "ListAPIsResponseMsg", "ListProfilesMsg", "ListProfilesResponseMsg", "ConfigReadMsg", "ConfigReadResponseMsg", "PromptMsg", "PromptResponseMsg", "ConfirmMsg", "ConfirmResponseMsg", "ResponseMsg", "DoneMsg", "StdoutDataMsg", "StderrDataMsg", "WarnMsg", "ProgressMsg", "SpinnerMsg", "LogMsg", "StdinDataMsg", "StdinCloseMsg"},
+		{"InitMsg", "HTTPRequestMsg", "HTTPResponseMsg", "APISpecMsg", "APISpecResponseMsg", "APIOperation", "APIParam", "ListAPIsMsg", "ListAPIsResponseMsg", "ListProfilesMsg", "ListProfilesResponseMsg", "ConfigReadMsg", "ConfigReadResponseMsg", "PromptMsg", "PromptResponseMsg", "ConfirmMsg", "ConfirmResponseMsg", "SelectOption", "SelectMsg", "SelectResponseMsg", "ResponseMsg", "DoneMsg", "StdoutDataMsg", "StderrDataMsg", "WarnMsg", "ProgressMsg", "SpinnerMsg", "LogMsg", "StdinDataMsg", "StdinCloseMsg"},
 		{"FormatterResponse", "FormatterRequest", "LoaderRequest", "LoaderResponse"},
 		{"HookRequest", "HookRequestHeaderUpdate", "AuthHookInput", "AuthHookOutput", "RequestMiddlewareInput", "RequestMiddlewareOutput", "HookResponse", "ResponseMiddlewareInput", "FollowRequest", "HookResponseUpdate", "ResponseMiddlewareOutput"},
 		{"TLSSignerInitMsg", "TLSSignerReadyMsg", "TLSSignerSignMsg", "TLSSignerSignedMsg", "TLSSignerShutdownMsg"},

--- a/docs/design/020-command-plugins.md
+++ b/docs/design/020-command-plugins.md
@@ -87,14 +87,12 @@ The current implementation handles these message types:
 
 - `http-request` to ask Restish to perform an HTTP call
 - `api-spec` to ask Restish to resolve a registered API spec
+- `prompt`, `confirm`, and `select` for host-owned user interaction
 - `response` to ask Restish to format and print a normalized response
 - `stdout-data` and `stderr-data` to write raw bytes directly
 - `progress`, `spinner`, and `log` to print status text on stderr
 - `warn` to print a warning-prefixed message
 - `done` to terminate with an exit code
-
-Prompt/confirm style interactions are also valid protocol concepts when a
-plugin needs host-owned prompting behavior.
 
 ### Messages From Restish To Plugin
 
@@ -103,6 +101,7 @@ Restish currently sends:
 - `init` when the command starts
 - `http-response` after handling an `http-request`
 - `api-spec-response` after handling an `api-spec`
+- `prompt-response`, `confirm-response`, and `select-response` after user interaction
 - `stdin-data` and `stdin-close` when `passthrough_stdio` is enabled
 
 Long-lived request/response pairs use `request_id` correlation identifiers so
@@ -111,6 +110,23 @@ continues reading plugin messages while HTTP work runs, and replies include the
 same `request_id` as the original request. The public `CommandClient.Do` helper
 assigns request IDs when needed and routes replies back to the goroutine that
 sent the request.
+
+`select` carries options with user-visible `label` and opaque plugin-owned
+`value` fields. Restish renders up to ten choices at a time on stderr. Up and
+Down move the selection, Enter returns the selected value, and Ctrl-C cancels
+the picker. A single option returns immediately. Multiple options
+require an interactive terminal and are unavailable to commands using
+`passthrough_stdio` because the host and plugin would otherwise compete for
+stdin.
+
+Plugins that require selection declare `command.select` in
+`required_features`. Older hosts then reject the plugin during discovery rather
+than waiting indefinitely for an unknown message type.
+
+Only one host-owned prompt, confirmation, or selection may be active per
+command session. Concurrent interaction requests receive an error. Plugins
+should also avoid writing terminal output while waiting for a selection because
+it can disrupt the picker display.
 
 For `passthrough_stdio`, the public client dispatches `stdin-data` and
 `stdin-close` through a bounded asynchronous queue. Slow stdin consumers must

--- a/docs/design/032-implementation-contract.md
+++ b/docs/design/032-implementation-contract.md
@@ -198,12 +198,13 @@ All plugin messages use CBOR. The stable message families are:
 | Manifest/startup flags | host -> plugin process | Discover hooks, loaders, formatters, and commands. |
 | Hook messages | host <-> short-lived plugin | Auth, request middleware, response middleware, loader, formatter hooks. |
 | Command messages | host <-> long-lived plugin | Init, stdin, HTTP delegation, formatting delegation, stderr, done. |
-| Config messages | plugin -> host | Read/list config and prompt/confirm where allowed. |
+| Config messages | plugin -> host | Read/list config and prompt/confirm/select where allowed. |
 | Formatter messages | host <-> formatter plugin | Normalize host response and stream or document formatting. |
 | TLS signer messages | host <-> signer plugin | Certificate discovery and signing for mTLS. |
 
 Protocol changes that alter message meaning require a plugin API version bump or
-explicit compatibility handling.
+explicit compatibility handling. Additive command interactions use manifest
+`required_features`; interactive selection is negotiated as `command.select`.
 
 ## Output Ownership
 

--- a/docs/plugin-quickstart.md
+++ b/docs/plugin-quickstart.md
@@ -176,12 +176,21 @@ profiles, err := c.ListProfiles("myapi")
 cfg, err := c.ConfigRead("myapi", "default", "hello-cmd")
 answer, err := c.Prompt("Label", false)
 ok, err := c.Confirm("Continue?")
+choice, err := c.Select("Choose an environment", []plugin.SelectOption{
+	{Label: "Development", Value: "dev"},
+	{Label: "Production", Value: "prod"},
+})
 err = c.Response(200, nil, map[string]any{"configured": cfg.PluginConfig != nil})
 ```
 
+Plugins that call `Select` must include `plugin.FeatureCommandSelect` in the
+manifest's `RequiredFeatures`. Restish keeps the picker on stderr and returns
+the selected option's opaque value. Selection requires an interactive terminal
+unless only one option is available.
+
 The context-aware variants (`ListAPIsContext`, `ConfigReadContext`,
-`PromptContext`, and friends) let plugins bound waits when the host is busy or
-the user does not answer.
+`PromptContext`, `SelectContext`, and friends) let plugins bound waits when the
+host is busy or the user does not answer.
 
 ## Local Development Loop
 

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/itchyny/gojq v0.12.19
 	github.com/mattn/go-isatty v0.0.20
+	github.com/mattn/go-runewidth v0.0.20
 	github.com/miekg/pkcs11 v1.0.3-0.20190429190417-a667d056470f
 	github.com/pb33f/libopenapi v0.35.0
 	github.com/sandrolain/httpcache v1.4.0
@@ -50,7 +51,6 @@ require (
 	github.com/itchyny/timefmt-go v0.1.8 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
-	github.com/mattn/go-runewidth v0.0.20 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect

--- a/internal/cli/command_plugin_handlers.go
+++ b/internal/cli/command_plugin_handlers.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c *CLI) handleCommandPluginMessage(cmd *cobra.Command, requestCtx context.Context, writer *commandPluginWriter, requestWG *sync.WaitGroup, msgType string, raw []byte) (bool, error) {
+func (c *CLI) handleCommandPluginMessage(cmd *cobra.Command, requestCtx context.Context, writer *commandPluginWriter, requestWG *sync.WaitGroup, interactionMu *sync.Mutex, passthroughStdio bool, msgType string, raw []byte) (bool, error) {
 	if len(raw) > maxCommandPluginInboundMessageBytes {
 		return false, fmt.Errorf("command plugin: message %s exceeded %d bytes", msgType, maxCommandPluginInboundMessageBytes)
 	}
@@ -80,13 +80,55 @@ func (c *CLI) handleCommandPluginMessage(cmd *cobra.Command, requestCtx context.
 		if err := decodeCommandPluginMessage(msgType, raw, &msg); err != nil {
 			return false, err
 		}
+		if interactionMu != nil && !interactionMu.TryLock() {
+			return false, writer.WriteMessage(pluginwire.PromptResponseMsg{
+				Type: pluginwire.MsgTypePromptResponse, RequestID: msg.RequestID,
+				Error: "another host interaction is active",
+			})
+		}
+		if interactionMu != nil {
+			defer interactionMu.Unlock()
+		}
 		return false, c.handlePluginPrompt(cmd.Context(), writer, msg)
 	case pluginwire.MsgTypeConfirm:
 		var msg pluginwire.ConfirmMsg
 		if err := decodeCommandPluginMessage(msgType, raw, &msg); err != nil {
 			return false, err
 		}
+		if interactionMu != nil && !interactionMu.TryLock() {
+			return false, writer.WriteMessage(pluginwire.ConfirmResponseMsg{
+				Type: pluginwire.MsgTypeConfirmResponse, RequestID: msg.RequestID,
+				Error: "another host interaction is active",
+			})
+		}
+		if interactionMu != nil {
+			defer interactionMu.Unlock()
+		}
 		return false, c.handlePluginConfirm(cmd.Context(), writer, msg)
+	case pluginwire.MsgTypeSelect:
+		var msg pluginwire.SelectMsg
+		if err := decodeCommandPluginMessage(msgType, raw, &msg); err != nil {
+			return false, err
+		}
+		if passthroughStdio && len(msg.Options) > 1 {
+			return false, writer.WriteMessage(pluginwire.SelectResponseMsg{
+				Type: pluginwire.MsgTypeSelectResponse, RequestID: msg.RequestID,
+				Error: "select is unavailable for passthrough_stdio commands",
+			})
+		}
+		if !interactionMu.TryLock() {
+			return false, writer.WriteMessage(pluginwire.SelectResponseMsg{
+				Type: pluginwire.MsgTypeSelectResponse, RequestID: msg.RequestID,
+				Error: "another host interaction is active",
+			})
+		}
+		requestWG.Add(1)
+		go func() {
+			defer requestWG.Done()
+			defer interactionMu.Unlock()
+			_ = c.handlePluginSelect(requestCtx, writer, msg)
+		}()
+		return false, nil
 	case pluginwire.MsgTypeResponse:
 		var msg pluginwire.ResponseMsg
 		if err := decodeCommandPluginMessage(msgType, raw, &msg); err != nil {
@@ -460,6 +502,15 @@ func (c *CLI) handlePluginConfirm(ctx context.Context, writer *commandPluginWrit
 		RequestID: msg.RequestID,
 		Value:     confirmed,
 	})
+}
+
+func (c *CLI) handlePluginSelect(ctx context.Context, writer *commandPluginWriter, msg pluginwire.SelectMsg) error {
+	value, err := c.selectOne(ctx, msg.Message, msg.Options)
+	reply := pluginwire.SelectResponseMsg{Type: pluginwire.MsgTypeSelectResponse, RequestID: msg.RequestID, Value: value}
+	if err != nil {
+		reply.Error, reply.Value = err.Error(), ""
+	}
+	return writer.WriteMessage(reply)
 }
 
 func (c *CLI) handlePluginConfigRead(writer *commandPluginWriter, msg pluginwire.ConfigReadMsg) error {

--- a/internal/cli/command_plugin_internal_test.go
+++ b/internal/cli/command_plugin_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -36,7 +37,7 @@ func TestHandleCommandPluginMessageRejectsMalformedDone(t *testing.T) {
 		t.Fatalf("marshal: %v", err)
 	}
 
-	done, gotErr := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, "done", raw)
+	done, gotErr := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, nil, false, "done", raw)
 	if !done {
 		t.Fatal("expected malformed done message to stop processing")
 	}
@@ -63,7 +64,7 @@ func TestHandleCommandPluginMessageRejectsOversizedStdoutData(t *testing.T) {
 		t.Fatalf("marshal: %v", err)
 	}
 
-	done, gotErr := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, pluginwire.MsgTypeStdoutData, raw)
+	done, gotErr := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, nil, false, pluginwire.MsgTypeStdoutData, raw)
 	if done {
 		t.Fatal("stdout-data should not mark command plugin done")
 	}
@@ -93,7 +94,7 @@ func TestHandleCommandPluginMessageRejectsOversizedStderrData(t *testing.T) {
 		t.Fatalf("marshal: %v", err)
 	}
 
-	done, gotErr := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, pluginwire.MsgTypeStderrData, raw)
+	done, gotErr := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, nil, false, pluginwire.MsgTypeStderrData, raw)
 	if done {
 		t.Fatal("stderr-data should not mark command plugin done")
 	}
@@ -105,6 +106,52 @@ func TestHandleCommandPluginMessageRejectsOversizedStderrData(t *testing.T) {
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("oversized stderr data was written: %d bytes", stderr.Len())
+	}
+}
+
+func TestHandleCommandPluginSelect(t *testing.T) {
+	var stderr, response bytes.Buffer
+	cli := &CLI{Stderr: &stderr}
+	cli.hooks.PassReader = strings.NewReader("\x1b[B\r")
+	cmd := &cobra.Command{Use: "test"}
+	cmd.SetErr(&stderr)
+	request := pluginwire.SelectMsg{
+		Type:      pluginwire.MsgTypeSelect,
+		RequestID: "select-1",
+		Message:   "Choose a pet",
+		Options: []pluginwire.SelectOption{
+			{Label: "Mochi", Value: "42"},
+			{Label: "Pixel", Value: "7"},
+		},
+	}
+	raw, err := cbor.Marshal(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer := &commandPluginWriter{w: &response}
+	var requestWG sync.WaitGroup
+	var interactionMu sync.Mutex
+	if done, err := cli.handleCommandPluginMessage(cmd, context.Background(), writer, &requestWG, &interactionMu, false, pluginwire.MsgTypeSelect, raw); err != nil || done {
+		t.Fatalf("handle select = done %v, err %v", done, err)
+	}
+	requestWG.Wait()
+	var reply pluginwire.SelectResponseMsg
+	if err := pluginwire.NewDecoder(&response).ReadMessage(&reply); err != nil {
+		t.Fatal(err)
+	}
+	if reply.RequestID != "select-1" || reply.Value != "7" || reply.Error != "" {
+		t.Fatalf("select response = %#v", reply)
+	}
+
+	response.Reset()
+	if done, err := cli.handleCommandPluginMessage(cmd, context.Background(), writer, &requestWG, &interactionMu, true, pluginwire.MsgTypeSelect, raw); err != nil || done {
+		t.Fatalf("handle passthrough select = done %v, err %v", done, err)
+	}
+	if err := pluginwire.NewDecoder(&response).ReadMessage(&reply); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(reply.Error, "passthrough_stdio") {
+		t.Fatalf("passthrough response = %#v", reply)
 	}
 }
 

--- a/internal/cli/command_plugin_runtime.go
+++ b/internal/cli/command_plugin_runtime.go
@@ -191,6 +191,7 @@ func (c *CLI) runCommandPlugin(cmd *cobra.Command, pluginPath string, decl plugi
 	var loopErr error
 	doneReceived := false
 	var requestWG sync.WaitGroup
+	var interactionMu sync.Mutex
 	requestCtx, cancelRequests := context.WithCancel(cmd.Context())
 	defer cancelRequests()
 	dec := pluginwire.NewDecoder(stdoutPipe)
@@ -211,7 +212,7 @@ func (c *CLI) runCommandPlugin(cmd *cobra.Command, pluginPath string, decl plugi
 			break
 		}
 
-		done, err := c.handleCommandPluginMessage(cmd, requestCtx, writer, &requestWG, pluginwire.MessageType(raw), raw)
+		done, err := c.handleCommandPluginMessage(cmd, requestCtx, writer, &requestWG, &interactionMu, decl.PassthroughStdio, pluginwire.MessageType(raw), raw)
 		if err != nil {
 			loopErr = err
 			break

--- a/internal/cli/command_plugin_test.go
+++ b/internal/cli/command_plugin_test.go
@@ -83,6 +83,48 @@ func TestCommandPluginGreet(t *testing.T) {
 	}
 }
 
+func TestCommandPluginSelect(t *testing.T) {
+	installCmdPlugin(t)
+
+	c, out, _ := newTestCLI(t)
+	var errOut captureWriter
+	c.Stderr = &errOut
+	c.Hooks().PassReader = strings.NewReader("\x1b[B\r")
+	c.Hooks().ConfigPath = sharedPluginConfigPath(t)
+	if err := c.Run([]string{"restish", "choose"}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"selected":"7"`) {
+		t.Fatalf("selector stdout = %q", out.String())
+	}
+	if output := errOut.String(); !strings.Contains(output, "Mochi") || !strings.Contains(output, "Pixel") {
+		t.Fatalf("selector stderr = %q", output)
+	}
+}
+
+func TestCommandPluginAbandonedSelectDoesNotBlock(t *testing.T) {
+	installCmdPlugin(t)
+
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = reader.Close()
+		_ = writer.Close()
+	})
+	c, _, _ := newTestCLI(t)
+	c.Hooks().PassReader = reader
+	c.Hooks().ConfigPath = sharedPluginConfigPath(t)
+	start := time.Now()
+	if err := c.Run([]string{"restish", "abandon"}); err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("abandoned selector blocked for %v", elapsed)
+	}
+}
+
 func TestCommandPluginFetch(t *testing.T) {
 	installCmdPlugin(t)
 

--- a/internal/cli/selector.go
+++ b/internal/cli/selector.go
@@ -1,0 +1,217 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"unicode"
+
+	"github.com/mattn/go-runewidth"
+	"github.com/rest-sh/restish/v2/internal/output"
+	pluginwire "github.com/rest-sh/restish/v2/plugin"
+	"golang.org/x/term"
+)
+
+var errSelectCanceled = errors.New("selection canceled")
+
+const selectWindowSize = 10
+
+func (c *CLI) selectOne(ctx context.Context, message string, options []pluginwire.SelectOption) (value string, err error) {
+	if len(options) == 0 {
+		return "", fmt.Errorf("select requires at least one option")
+	}
+	labels := make([]string, len(options))
+	for i, option := range options {
+		if option.Label == "" {
+			return "", fmt.Errorf("select option %d has an empty label", i+1)
+		}
+		labels[i] = selectLine(option.Label)
+	}
+	if len(options) == 1 {
+		return options[0].Value, nil
+	}
+	src, cleanup, owned, err := c.selectSource()
+	if err != nil {
+		return "", err
+	}
+	defer cleanup()
+	restore := func() error { return nil }
+	if f, ok := src.(*os.File); ok && output.IsTerminalReader(f) {
+		fd := int(f.Fd())
+		state, rawErr := term.MakeRaw(fd)
+		if rawErr != nil {
+			return "", fmt.Errorf("select: enable raw terminal: %w", rawErr)
+		}
+		var once sync.Once
+		var restoreErr error
+		restore = func() error {
+			once.Do(func() { restoreErr = term.Restore(fd, state) })
+			return restoreErr
+		}
+		defer func() {
+			if restoreErr := restore(); err == nil && restoreErr != nil {
+				err = fmt.Errorf("select: restore terminal: %w", restoreErr)
+			}
+		}()
+	}
+	cancelWatchDone := make(chan struct{})
+	if f, ok := src.(*os.File); ok && owned {
+		go func() {
+			select {
+			case <-ctx.Done():
+				_ = restore()
+				_ = f.Close()
+			case <-cancelWatchDone:
+			}
+		}()
+	}
+	defer close(cancelWatchDone)
+	reader := newCancelableStdinReader(src, ctx.Done())
+	width, height := 80, 24
+	if f, ok := src.(*os.File); ok {
+		if terminalWidth, terminalHeight, sizeErr := term.GetSize(int(f.Fd())); sizeErr == nil && terminalWidth > 0 && terminalHeight > 2 {
+			width, height = terminalWidth, terminalHeight
+		}
+	}
+	selected, drawn := 0, 0
+	for {
+		drawn, err = drawSelect(c.Stderr, message, labels, selected, drawn, width, height)
+		if err != nil {
+			return "", fmt.Errorf("select: render: %w", err)
+		}
+		key, readErr := readSelectKey(reader)
+		if readErr != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return "", ctxErr
+			}
+			return "", fmt.Errorf("select: read input: %w", readErr)
+		}
+		switch key {
+		case selectKeyUp:
+			selected = (selected - 1 + len(options)) % len(options)
+		case selectKeyDown:
+			selected = (selected + 1) % len(options)
+		case selectKeyEnter:
+			return options[selected].Value, nil
+		case selectKeyCancel:
+			return "", errSelectCanceled
+		}
+	}
+}
+
+func (c *CLI) selectSource() (io.Reader, func(), bool, error) {
+	if c.hooks.PassReader != nil {
+		return c.hooks.PassReader, func() {}, false, nil
+	}
+	if !output.IsTerminal(c.Stderr) {
+		return nil, nil, false, fmt.Errorf("select requires an interactive terminal")
+	}
+	if f, err := promptOpenTTY(); err == nil {
+		if output.IsTerminalReader(f) {
+			return f, func() { _ = f.Close() }, true, nil
+		}
+		_ = f.Close()
+	}
+	if output.IsTerminalReader(c.Stdin) {
+		return c.Stdin, func() {}, false, nil
+	}
+	return nil, nil, false, fmt.Errorf("select requires an interactive terminal")
+}
+
+type selectKey byte
+
+const (
+	selectKeyNone selectKey = iota
+	selectKeyUp
+	selectKeyDown
+	selectKeyEnter
+	selectKeyCancel
+)
+
+func readSelectKey(r io.Reader) (selectKey, error) {
+	var b [1]byte
+	if _, err := io.ReadFull(r, b[:]); err != nil {
+		return selectKeyNone, err
+	}
+	switch b[0] {
+	case '\r', '\n':
+		return selectKeyEnter, nil
+	case 3:
+		return selectKeyCancel, nil
+	case 0, 0xe0:
+		if _, err := io.ReadFull(r, b[:]); err != nil {
+			return selectKeyNone, err
+		}
+		if b[0] == 72 {
+			return selectKeyUp, nil
+		}
+		if b[0] == 80 {
+			return selectKeyDown, nil
+		}
+	case 0x1b:
+		var sequence [2]byte
+		if _, err := io.ReadFull(r, sequence[:]); err != nil {
+			return selectKeyNone, err
+		}
+		if sequence[0] == '[' || sequence[0] == 'O' {
+			if sequence[1] == 'A' {
+				return selectKeyUp, nil
+			}
+			if sequence[1] == 'B' {
+				return selectKeyDown, nil
+			}
+		}
+	}
+	return selectKeyNone, nil
+}
+
+func drawSelect(w io.Writer, message string, labels []string, selected, previousLines, width, height int) (int, error) {
+	visible := min(len(labels), selectWindowSize, max(1, height-2))
+	start := max(0, selected-visible/2)
+	start = min(start, len(labels)-visible)
+	var screen strings.Builder
+	if previousLines > 0 {
+		fmt.Fprintf(&screen, "\x1b[%dA", previousLines)
+	}
+	message = selectLine(message)
+	if message == "" {
+		message = "Select"
+	}
+	suffix := fmt.Sprintf(" (%d/%d, arrow keys, Enter)", selected+1, len(labels))
+	if width < runewidth.StringWidth(suffix)+8 {
+		suffix = fmt.Sprintf(" (%d/%d)", selected+1, len(labels))
+	}
+	message = fitSelectLine(message, max(1, width-runewidth.StringWidth(suffix)))
+	fmt.Fprintf(&screen, "\r\x1b[2K%s%s\n", message, suffix)
+	for i := start; i < start+visible; i++ {
+		prefix := "  "
+		if i == selected {
+			prefix = "> "
+		}
+		fmt.Fprintf(&screen, "\r\x1b[2K%s%s\n", prefix, fitSelectLine(labels[i], max(1, width-2)))
+	}
+	screen.WriteByte('\r')
+	_, err := io.WriteString(w, screen.String())
+	return visible + 1, err
+}
+
+func fitSelectLine(value string, width int) string {
+	tail := ""
+	if width > 3 && runewidth.StringWidth(value) > width {
+		tail = "..."
+	}
+	return runewidth.Truncate(value, width, tail)
+}
+
+func selectLine(value string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsGraphic(r) {
+			return r
+		}
+		return ' '
+	}, value)
+}

--- a/internal/cli/selector_test.go
+++ b/internal/cli/selector_test.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	pluginwire "github.com/rest-sh/restish/v2/plugin"
+)
+
+func TestSelectOneNavigation(t *testing.T) {
+	options := []pluginwire.SelectOption{{Label: "Mochi", Value: "42"}, {Label: "Pixel", Value: "7"}}
+	tests := []struct {
+		name, input, want string
+	}{
+		{name: "enter selects first", input: "\r", want: "42"},
+		{name: "down selects second", input: "\x1b[B\r", want: "7"},
+		{name: "up wraps to last", input: "\x1b[A\r", want: "7"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			c := &CLI{Stderr: &stderr}
+			c.hooks.PassReader = strings.NewReader(tt.input)
+			got, err := c.selectOne(context.Background(), "Choose\npet", options)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("selectOne = %q, want %q", got, tt.want)
+			}
+			if output := stderr.String(); !strings.Contains(output, "Choose pet") || !strings.Contains(output, "Pixel") {
+				t.Fatalf("selector output = %q", output)
+			}
+		})
+	}
+}
+
+func TestSelectOneBoundaries(t *testing.T) {
+	c := &CLI{Stdin: strings.NewReader("must not be read"), Stderr: &bytes.Buffer{}}
+	if _, err := c.selectOne(context.Background(), "Choose", nil); err == nil {
+		t.Fatal("empty options accepted")
+	}
+	if got, err := c.selectOne(context.Background(), "Choose", []pluginwire.SelectOption{{Label: "Only", Value: "one"}}); err != nil || got != "one" {
+		t.Fatalf("single option = %q, %v", got, err)
+	}
+	if _, err := c.selectOne(context.Background(), "Choose", []pluginwire.SelectOption{{Label: "One"}, {Label: "Two"}}); err == nil {
+		t.Fatal("non-interactive selection accepted")
+	}
+	c.hooks.PassReader = strings.NewReader("\x03")
+	if _, err := c.selectOne(context.Background(), "Choose", []pluginwire.SelectOption{{Label: "One"}, {Label: "Two"}}); !errors.Is(err, errSelectCanceled) {
+		t.Fatalf("Ctrl-C error = %v", err)
+	}
+}

--- a/internal/cli/testdata/testplugin/main.go
+++ b/internal/cli/testdata/testplugin/main.go
@@ -49,6 +49,8 @@ func runManifestOnlyPlugin() {
 var commandPluginCommands = []plugin.CommandDecl{
 	{Name: "greet", Short: "Greet the user"},
 	{Name: "fetch", Short: "Fetch a URL via Restish"},
+	{Name: "choose", Short: "Choose a pet via Restish"},
+	{Name: "abandon", Short: "Abandon a selection"},
 	{Name: "pipe", Short: "Echo stdin via passthrough stdio", PassthroughStdio: true},
 	{Name: "fail", Short: "Exit with code 1"},
 	{Name: "die", Short: "Crash unexpectedly"},
@@ -62,6 +64,7 @@ func runCommandPlugin() {
 		Description:       "Test command plugin",
 		RestishAPIVersion: 2,
 		Hooks:             []string{"command"},
+		RequiredFeatures:  []string{plugin.FeatureCommandSelect},
 	}, commandPluginCommands) {
 		return
 	}
@@ -84,6 +87,14 @@ func runCommandPlugin() {
 		_ = plugin.WriteMessage(os.Stdout, plugin.DoneMsg{Type: plugin.MsgTypeDone})
 	case "fetch":
 		runCommandPluginFetch(dec, initMsg.Args)
+	case "choose":
+		runCommandPluginSelect(dec)
+	case "abandon":
+		_ = plugin.WriteMessage(os.Stdout, plugin.SelectMsg{
+			Type: plugin.MsgTypeSelect, RequestID: "abandoned", Message: "Choose",
+			Options: []plugin.SelectOption{{Label: "One", Value: "1"}, {Label: "Two", Value: "2"}},
+		})
+		_ = plugin.WriteMessage(os.Stdout, plugin.DoneMsg{Type: plugin.MsgTypeDone})
 	case "fail":
 		_ = plugin.WriteMessage(os.Stdout, plugin.DoneMsg{Type: plugin.MsgTypeDone, ExitCode: 1})
 	case "pipe":
@@ -97,6 +108,22 @@ func runCommandPlugin() {
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", initMsg.Command)
 		_ = plugin.WriteMessage(os.Stdout, plugin.DoneMsg{Type: plugin.MsgTypeDone, ExitCode: 1})
 	}
+}
+
+func runCommandPluginSelect(dec *plugin.Decoder) {
+	_ = plugin.WriteMessage(os.Stdout, plugin.SelectMsg{
+		Type: plugin.MsgTypeSelect, RequestID: "select-1", Message: "Choose a pet",
+		Options: []plugin.SelectOption{{Label: "Mochi", Value: "42"}, {Label: "Pixel", Value: "7"}},
+	})
+	var reply plugin.SelectResponseMsg
+	if err := dec.ReadMessage(&reply); err != nil || reply.Error != "" {
+		_ = plugin.WriteMessage(os.Stdout, plugin.DoneMsg{Type: plugin.MsgTypeDone, ExitCode: 1})
+		return
+	}
+	_ = plugin.WriteMessage(os.Stdout, plugin.ResponseMsg{
+		Type: plugin.MsgTypeResponse, Status: 200, Body: map[string]any{"selected": reply.Value},
+	})
+	_ = plugin.WriteMessage(os.Stdout, plugin.DoneMsg{Type: plugin.MsgTypeDone})
 }
 
 func runCommandPluginFetch(dec *plugin.Decoder, args []string) {

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -48,6 +48,7 @@ var supportedRequiredFeatures = map[string]bool{
 	pluginwire.FeatureManifestRequiredFeatures: true,
 	pluginwire.FeatureLoaderSourceMetadata:     true,
 	pluginwire.FeatureRequestFinalBody:         true,
+	pluginwire.FeatureCommandSelect:            true,
 }
 
 var renameManifestCacheFile = os.Rename
@@ -85,15 +86,21 @@ func Discover(pluginDir string, errFn func(path string, err error), manifestCach
 			mtime := info.ModTime().UnixNano()
 			size := info.Size()
 			if entry, ok := cache[path]; ok && entry.Mtime == mtime && entry.Size == size {
-				m := entry.Manifest
-				return &m, nil
+				if len(entry.Manifest.RequiredFeatures) == 0 {
+					m := entry.Manifest
+					return &m, nil
+				}
+				delete(cache, path)
+				cacheUpdated = true
 			}
 			m, err := loadManifest(path, stderr)
 			if err != nil {
 				return nil, err
 			}
-			cache[path] = manifestCacheEntry{Mtime: mtime, Size: size, Manifest: *m}
-			cacheUpdated = true
+			if len(m.RequiredFeatures) == 0 {
+				cache[path] = manifestCacheEntry{Mtime: mtime, Size: size, Manifest: *m}
+				cacheUpdated = true
+			}
 			return m, nil
 		}
 		return loadManifest(path, stderr)

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -284,6 +284,10 @@ func TestLoadManifest_CompatibilityMatrix(t *testing.T) {
 			name: "supported required feature",
 			json: `{"name":"supported","restish_api_version":2,"hooks":["loader"],"loader_content_types":["application/x-test"],"required_features":["loader.source_metadata"]}`,
 		},
+		{
+			name: "select required feature",
+			json: `{"name":"select","restish_api_version":2,"hooks":["command"],"required_features":["command.select"]}`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -555,6 +559,40 @@ echo '%s'
 	}
 	if string(bytes.TrimSpace(count)) != "1" {
 		t.Fatalf("cached discover counter = %q, want 1", bytes.TrimSpace(count))
+	}
+}
+
+func TestDiscover_DoesNotCacheRequiredFeatures(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script tests not supported on Windows")
+	}
+	dir := t.TempDir()
+	cacheFile := filepath.Join(t.TempDir(), "plugin-manifest-cache.cbor")
+	counterFile := filepath.Join(dir, "manifest-count")
+	m := Manifest{
+		Name: "select", RestishAPIVersion: CurrentPluginAPIVersion,
+		Hooks: []string{"command"}, RequiredFeatures: []string{pluginwire.FeatureCommandSelect},
+	}
+	script := fmt.Sprintf(`#!/bin/sh
+count=0
+if [ -f %q ]; then count=$(cat %q); fi
+count=$((count + 1))
+echo "$count" > %q
+echo '%s'
+`, counterFile, counterFile, counterFile, jsonManifest(m))
+	writeScript(t, dir, "restish-select", script)
+
+	for range 2 {
+		if plugins := Discover(dir, nil, cacheFile, nil); len(plugins) != 1 {
+			t.Fatalf("discover: got %d plugins, want 1", len(plugins))
+		}
+	}
+	count, err := os.ReadFile(counterFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(bytes.TrimSpace(count)) != "2" {
+		t.Fatalf("manifest executions = %q, want 2", bytes.TrimSpace(count))
 	}
 }
 

--- a/plugin/client.go
+++ b/plugin/client.go
@@ -229,6 +229,23 @@ func (c *CommandClient) ConfirmContext(ctx context.Context, message string) (*Co
 	return &reply, nil
 }
 
+// Select asks the host to display a single-choice picker.
+func (c *CommandClient) Select(message string, options []SelectOption) (*SelectResponseMsg, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	return c.SelectContext(ctx, message, options)
+}
+
+// SelectContext asks the host to display a single-choice picker, returning
+// when ctx is canceled if the host does not reply.
+func (c *CommandClient) SelectContext(ctx context.Context, message string, options []SelectOption) (*SelectResponseMsg, error) {
+	var reply SelectResponseMsg
+	if err := c.roundTrip(ctx, MsgTypeSelectResponse, &SelectMsg{Type: MsgTypeSelect, Message: message, Options: options}, &reply); err != nil {
+		return nil, err
+	}
+	return &reply, nil
+}
+
 // Response asks the host to format and display response data using the same
 // output machinery as regular Restish responses.
 func (c *CommandClient) Response(status int, headers map[string][]string, body any) error {
@@ -293,6 +310,8 @@ func (c *CommandClient) readLoop() {
 			c.deliverResponseByRequestID(MsgTypePromptResponse, raw)
 		case MsgTypeConfirmResponse:
 			c.deliverResponseByRequestID(MsgTypeConfirmResponse, raw)
+		case MsgTypeSelectResponse:
+			c.deliverResponseByRequestID(MsgTypeSelectResponse, raw)
 		case MsgTypeStdinData:
 			if c.StdinDataHandler != nil {
 				var msg StdinDataMsg
@@ -483,6 +502,8 @@ func setRequestID(msg any, requestID string) {
 	case *PromptMsg:
 		m.RequestID = requestID
 	case *ConfirmMsg:
+		m.RequestID = requestID
+	case *SelectMsg:
 		m.RequestID = requestID
 	case *APISpecMsg:
 		m.RequestID = requestID

--- a/plugin/client_test.go
+++ b/plugin/client_test.go
@@ -492,6 +492,47 @@ func TestCommandClientHelpersRouteConcurrentRepliesByRequestID(t *testing.T) {
 	}
 }
 
+func TestCommandClientSelect(t *testing.T) {
+	hostToPluginR, hostToPluginW := io.Pipe()
+	pluginToHostR, pluginToHostW := io.Pipe()
+	defer hostToPluginR.Close()
+	defer hostToPluginW.Close()
+	defer pluginToHostR.Close()
+	defer pluginToHostW.Close()
+
+	client := NewCommandClient(hostToPluginR, pluginToHostW)
+	result := make(chan *SelectResponseMsg, 1)
+	errs := make(chan error, 1)
+	options := []SelectOption{{Label: "Mochi", Value: "42"}, {Label: "Pixel", Value: "7"}}
+	go func() {
+		reply, err := client.SelectContext(context.Background(), "Choose a pet", options)
+		if err != nil {
+			errs <- err
+			return
+		}
+		result <- reply
+	}()
+
+	var request SelectMsg
+	if err := NewDecoder(pluginToHostR).ReadMessage(&request); err != nil {
+		t.Fatal(err)
+	}
+	if request.Type != MsgTypeSelect || request.RequestID == "" || request.Message != "Choose a pet" || len(request.Options) != 2 || request.Options[1] != options[1] {
+		t.Fatalf("select request = %#v", request)
+	}
+	if err := WriteMessage(hostToPluginW, SelectResponseMsg{Type: MsgTypeSelectResponse, RequestID: request.RequestID, Value: "7"}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-errs:
+		t.Fatal(err)
+	case reply := <-result:
+		if reply.Value != "7" {
+			t.Fatalf("select response = %#v", reply)
+		}
+	}
+}
+
 func TestCommandClientHelpersWriteExpectedMessages(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -537,6 +578,16 @@ func TestCommandClientHelpersWriteExpectedMessages(t *testing.T) {
 				return err
 			},
 			wantType: MsgTypeConfirm,
+		},
+		{
+			name: "select",
+			call: func(c *CommandClient) error {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				_, err := c.SelectContext(ctx, "choose", []SelectOption{{Label: "One", Value: "1"}})
+				return err
+			},
+			wantType: MsgTypeSelect,
 		},
 	}
 	for _, tt := range tests {

--- a/plugin/doc.go
+++ b/plugin/doc.go
@@ -45,7 +45,7 @@
 //   - APISpecMsg / APISpecResponseMsg for fetching registered API specs
 //   - ListAPIsMsg / ListProfilesMsg for config discovery
 //   - ConfigReadMsg for effective API/profile/plugin config
-//   - PromptMsg / ConfirmMsg for user interaction
+//   - PromptMsg / ConfirmMsg / SelectMsg for user interaction
 //   - ResponseMsg, StdoutDataMsg, StderrDataMsg, WarnMsg, and DoneMsg for output
 //
 // For simple command plugins, plugin.Run and CommandClient are usually enough.

--- a/plugin/manifest.go
+++ b/plugin/manifest.go
@@ -35,6 +35,9 @@ const (
 	// FeatureRequestFinalBody means auth and request-middleware hooks may
 	// receive the final request body bytes when Restish has them.
 	FeatureRequestFinalBody = "request.final_body"
+	// FeatureCommandSelect means command plugins may request an interactive
+	// single-choice picker from the host.
+	FeatureCommandSelect = "command.select"
 )
 
 // Manifest is the metadata a plugin reports when called with

--- a/plugin/messages.go
+++ b/plugin/messages.go
@@ -13,6 +13,7 @@ const (
 	MsgTypeConfigRead   = "config-read"
 	MsgTypePrompt       = "prompt"
 	MsgTypeConfirm      = "confirm"
+	MsgTypeSelect       = "select"
 	MsgTypeResponse     = "response"
 	MsgTypeDone         = "done"
 	MsgTypeStdoutData   = "stdout-data"
@@ -30,6 +31,7 @@ const (
 	MsgTypeConfigReadResponse   = "config-read-response"
 	MsgTypePromptResponse       = "prompt-response"
 	MsgTypeConfirmResponse      = "confirm-response"
+	MsgTypeSelectResponse       = "select-response"
 
 	// Host → plugin passthrough-stdio data.
 	MsgTypeStdinData  = "stdin-data"
@@ -228,6 +230,28 @@ type ConfirmResponseMsg struct {
 	Type      string `cbor:"type"`
 	RequestID string `cbor:"request_id,omitempty"`
 	Value     bool   `cbor:"value"`
+	Error     string `cbor:"error,omitempty"`
+}
+
+// SelectOption pairs a user-visible label with an opaque plugin-owned value.
+type SelectOption struct {
+	Label string `cbor:"label"`
+	Value string `cbor:"value"`
+}
+
+// SelectMsg asks the host to display an interactive single-choice picker.
+type SelectMsg struct {
+	Type      string         `cbor:"type"`
+	RequestID string         `cbor:"request_id,omitempty"`
+	Message   string         `cbor:"message"`
+	Options   []SelectOption `cbor:"options"`
+}
+
+// SelectResponseMsg is the host reply to a SelectMsg.
+type SelectResponseMsg struct {
+	Type      string `cbor:"type"`
+	RequestID string `cbor:"request_id,omitempty"`
+	Value     string `cbor:"value,omitempty"`
 	Error     string `cbor:"error,omitempty"`
 }
 

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -127,6 +127,34 @@ func TestTypedMessageRoundTrip(t *testing.T) {
 	}
 }
 
+func TestSelectMessageWireShape(t *testing.T) {
+	var buf bytes.Buffer
+	err := plugin.WriteMessage(&buf, plugin.SelectMsg{
+		Type:      plugin.MsgTypeSelect,
+		RequestID: "req-1",
+		Message:   "Choose a pet",
+		Options:   []plugin.SelectOption{{Label: "Mochi", Value: "42"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]any
+	if err := plugin.ReadMessage(&buf, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded["type"] != "select" || decoded["request_id"] != "req-1" || decoded["message"] != "Choose a pet" {
+		t.Fatalf("select message = %#v", decoded)
+	}
+	options, ok := decoded["options"].([]any)
+	if !ok || len(options) != 1 {
+		t.Fatalf("select options = %#v", decoded["options"])
+	}
+	option, ok := options[0].(map[string]any)
+	if !ok || option["label"] != "Mochi" || option["value"] != "42" {
+		t.Fatalf("select option = %#v", options[0])
+	}
+}
+
 func TestCommandClientDoConcurrentRoutesByRequestID(t *testing.T) {
 	hostToPluginR, hostToPluginW := io.Pipe()
 	pluginToHostR, pluginToHostW := io.Pipe()

--- a/site/content/en/docs/plugins/command-plugins.md
+++ b/site/content/en/docs/plugins/command-plugins.md
@@ -16,7 +16,7 @@ Use a command plugin when a feature needs:
 - a top-level command
 - multiple HTTP requests
 - progress messages
-- prompts or confirmations
+- prompts, confirmations, or interactive selection
 - access to registered APIs and profiles
 
 Use a hook plugin for one request/response/auth/formatting task.
@@ -54,8 +54,30 @@ profiles, err := c.ListProfiles("example")
 cfg, err := c.ConfigRead("example", "default", "my-plugin")
 answer, err := c.Prompt("Label", false)
 ok, err := c.Confirm("Continue?")
+choice, err := c.Select("Choose an environment", []plugin.SelectOption{
+  {Label: "Development", Value: "dev"},
+  {Label: "Production", Value: "prod"},
+})
 err = c.Response(200, nil, map[string]any{"ok": ok, "apis": apis.APIs})
 ```
+
+`Select` renders a host-owned picker on stderr. Up and Down move through the
+options, Enter returns the selected value, and Ctrl-C cancels the picker.
+Labels are for display; values remain opaque to the host. Multiple options
+require an interactive terminal and cannot be used by commands with
+`passthrough_stdio`.
+
+Plugins that call `Select` must declare the additive feature in their manifest:
+
+```go
+RequiredFeatures: []string{plugin.FeatureCommandSelect},
+```
+
+This makes older Restish hosts reject the plugin during discovery instead of
+hanging on an unknown request.
+
+Wait for each host interaction before starting another, and avoid writing
+terminal output while a picker is active.
 
 Non-Go plugins can send the same message families directly:
 
@@ -79,7 +101,7 @@ Non-Go plugins can send the same message families directly:
 
 1. The plugin declares commands during startup discovery.
 2. Restish starts the plugin when the user runs the contributed command.
-3. The plugin sends requests such as `http-request`, `api-spec`, `prompt`, or `response`.
+3. The plugin sends requests such as `http-request`, `api-spec`, `select`, or `response`.
 4. The plugin sends `done` with an exit code.
 
 ## Real Examples

--- a/site/content/en/docs/plugins/quickstart.md
+++ b/site/content/en/docs/plugins/quickstart.md
@@ -36,7 +36,8 @@ change one capability at a time.
 
 Choose a hook when the plugin should do one focused job inside a request. Choose
 a command plugin when the plugin owns a multi-step workflow and needs host
-messages such as delegated HTTP, prompts, config reads, or formatted responses.
+messages such as delegated HTTP, prompts, selections, config reads, or formatted
+responses.
 
 ## Build And Install
 
@@ -95,8 +96,8 @@ flags.
 - Redact secrets.
 - Delegate HTTP to Restish from command plugins.
 - Keep operator documentation separate from protocol details.
-- Prefer host-provided request, response, config, prompt, and output helpers to
-  custom HTTP clients or custom terminal rendering.
+- Prefer host-provided request, response, config, prompt, selection, and output
+  helpers to custom HTTP clients or custom terminal rendering.
 - Keep hooks deterministic and bounded; Restish applies hook timeouts from the
   manifest or defaults.
 

--- a/site/content/en/docs/reference/plugin-manifest.md
+++ b/site/content/en/docs/reference/plugin-manifest.md
@@ -163,6 +163,7 @@ Supported `required_features` values are:
 | `manifest.required_features` | Host understands manifest required-feature validation. |
 | `loader.source_metadata` | Loader hooks may receive `content_type`, `source_url`, and `local_path`. |
 | `request.final_body` | Auth and request-middleware hooks may receive final request body bytes when Restish has them. |
+| `command.select` | Command plugins may request a host-owned single-choice picker. |
 
 ## Command Discovery
 

--- a/site/content/en/docs/reference/plugin-messages.md
+++ b/site/content/en/docs/reference/plugin-messages.md
@@ -42,6 +42,8 @@ Generated from `plugin/messages.go`.
 | `MsgTypePrompt` | `prompt` |
 | `MsgTypePromptResponse` | `prompt-response` |
 | `MsgTypeResponse` | `response` |
+| `MsgTypeSelect` | `select` |
+| `MsgTypeSelectResponse` | `select-response` |
 | `MsgTypeSpinner` | `spinner` |
 | `MsgTypeStderrData` | `stderr-data` |
 | `MsgTypeStdinClose` | `stdin-close` |
@@ -549,6 +551,61 @@ CBOR: `request_id`; type: `string`; required: no
 **`Value`**
 
 CBOR: `value`; type: `bool`; required: yes
+
+**`Error`**
+
+CBOR: `error`; type: `string`; required: no
+
+
+### `SelectOption`
+
+SelectOption pairs a user-visible label with an opaque plugin-owned value.
+
+**`Label`**
+
+CBOR: `label`; type: `string`; required: yes
+
+**`Value`**
+
+CBOR: `value`; type: `string`; required: yes
+
+
+### `SelectMsg`
+
+SelectMsg asks the host to display an interactive single-choice picker.
+
+**`Type`**
+
+CBOR: `type`; type: `string`; required: yes
+
+**`RequestID`**
+
+CBOR: `request_id`; type: `string`; required: no
+
+**`Message`**
+
+CBOR: `message`; type: `string`; required: yes
+
+**`Options`**
+
+CBOR: `options`; type: `[]SelectOption`; required: yes
+
+
+### `SelectResponseMsg`
+
+SelectResponseMsg is the host reply to a SelectMsg.
+
+**`Type`**
+
+CBOR: `type`; type: `string`; required: yes
+
+**`RequestID`**
+
+CBOR: `request_id`; type: `string`; required: no
+
+**`Value`**
+
+CBOR: `value`; type: `string`; required: no
 
 **`Error`**
 
@@ -1078,6 +1135,7 @@ generate and route those IDs.
 | `config-read` | optional `api`, `profile`, `plugin` | `config-read-response` with `base_url`, `headers`, `query`, `plugin_config`; auth secrets are excluded |
 | `prompt` | `message`, optional `hidden` | `prompt-response` with `value` or `error` |
 | `confirm` | `message` | `confirm-response` with boolean `value` or `error` |
+| `select` | `message`, `options` containing `label` and `value` | `select-response` with the selected opaque `value` or `error` |
 | `response` | `status`, `headers`, `body` | none; host formats it like a normal API response |
 | `stdout-data` / `stderr-data` | `data` bytes | none |
 | `progress` / `spinner` / `log` / `warn` | `text` | none |
@@ -1099,11 +1157,17 @@ list. Each operation includes fields such as `id`, `method`, `path`, `summary`,
 - `config-read-response`
 - `prompt-response`
 - `confirm-response`
+- `select-response`
 - `stdin-data`
 - `stdin-close`
 
 `stdin-data` and `stdin-close` are used only for command plugins that opt into
 passthrough stdio.
+
+Interactive selection is available only to plugins that declare the
+`command.select` required feature. Multiple options require a terminal and are
+not available with `passthrough_stdio`. Restish renders labels on stderr and
+returns values unchanged to the plugin.
 
 ## Hook Plugins
 


### PR DESCRIPTION
## Summary

- add typed `select` and `select-response` command-plugin messages with display labels and opaque values
- add a host-owned single-choice picker with arrow navigation, terminal-aware sizing, cancellation, and serialized interaction handling
- negotiate the additive behavior through `command.select` and keep required-feature manifests uncached so older hosts revalidate them after a downgrade
- document the wire contract and cover client routing, host dispatch, terminal navigation, abandoned selections, and feature negotiation

Closes #419

## Behavior

The checked-in test command plugin was built from this branch. The before host was built from `v2.3.0`; the after host was built from this branch.

Before:

```console
$ ./restish-v2.3.0 --rsh-config /tmp/restish-select/config/restish.json choose
warning: plugin restish-cmdplugin: plugin restish-cmdplugin: manifest requires unsupported feature "command.select"
unknown command "choose" for "restish"; run "restish --help" to see available commands or use a full URL
```

After, sending Down then Enter through a pseudo-terminal:

```console
$ printf '\033[B\r' | script -qefE never -O /tmp/restish-select/session.log -- env NO_COLOR=1 ./restish --rsh-config /tmp/restish-select/config/restish.json choose
Choose a pet (1/2, arrow keys, Enter)
> Mochi
  Pixel
Choose a pet (2/2, arrow keys, Enter)
  Mochi
> Pixel
HTTP/1.1 200 OK

{
  "selected": "7"
}
```

The output above omits ANSI cursor-control bytes. A second end-to-end fixture sends `select` and immediately exits; the host cancels the picker and restores the terminal without waiting for input.

---

> [!NOTE]
> AI assistance: PR description, protocol documentation, test scaffolding.
