### PR TITLE
feat: add API-backed parameter completion

### DIFF
--- a/docs/design/016-setup-and-completions.md
+++ b/docs/design/016-setup-and-completions.md
@@ -82,6 +82,21 @@ Where Restish has enough metadata, completion should also surface:
 - profile names and similar finite sets
 - API-aware URL paths from generated operation metadata
 
+Parameter-level `x-cli-completion` is the explicit opt-in exception to offline
+completion. It may call a declared `GET` or `HEAD` operation from the same
+synced operation set to obtain values for a generated argument or flag. Static
+enum metadata takes precedence.
+
+The completion provider uses the normal profile, TLS, parameter serialization,
+origin, and built-in authentication paths, but completion remains
+non-interactive. It never retries, paginates, starts local plugins, runs command
+secret sources, or prompts. Requests and decoded results have fixed time, body,
+candidate-count, and candidate-length limits. Errors produce no candidates or
+human diagnostics. A short, bounded cache avoids a request on repeated `Tab`
+invocations for unauthenticated providers with the same API, profile, provider,
+bindings, selectors, and typed prefix. Authenticated candidates are not
+persisted.
+
 For zsh, `shell setup zsh` writes the generated script under Restish's effective
 config directory, not the cache directory, then adds a managed source block to
 `~/.zshrc`. The script is generated state, but shell startup depends on it

--- a/docs/design/030-security-model-and-trust-boundaries.md
+++ b/docs/design/030-security-model-and-trust-boundaries.md
@@ -189,6 +189,16 @@ metadata rather than a separate trust prompt: `api connect` and `api sync`
 summarize behavior-changing `x-cli-*` extension classes, while `doctor api`
 reports the affected paths, operations, and parameters in more detail.
 
+`x-cli-completion` is network-capable remote metadata. It can only reference a
+declared `GET` or `HEAD` operation in the same operation set, and the existing
+operation-origin policy remains authoritative. Completion requests have fixed
+deadlines and response limits, never retry or paginate, and suppress errors.
+They may use built-in non-interactive credentials, but do not prompt, run auth
+hooks, start local auth or TLS plugins, or resolve command-based secret sources.
+Only built-in response codecs and bounded field selectors run. Returned values
+and descriptions are bounded and stripped of terminal control characters before
+Cobra receives them.
+
 These rules apply both to `Link`-header discovery and well-known-path probes.
 
 ## Sensitive Data Handling

--- a/docs/design/034-openapi-implementation-contract.md
+++ b/docs/design/034-openapi-implementation-contract.md
@@ -137,12 +137,23 @@ Supported CLI-shaping extensions are:
 - `x-cli-description`
 - `x-cli-ignore`
 - `x-cli-hidden`
+- `x-cli-completion`
 
-These extensions apply to operations. `x-cli-ignore` and `x-cli-hidden` also
-apply at path scope where supported. Parameter-level `x-cli-name`,
+The naming, alias, description, ignore, and hidden extensions apply to
+operations. `x-cli-ignore` and `x-cli-hidden` also apply at path scope where
+supported. Parameter-level `x-cli-name`,
 `x-cli-description`, `x-cli-ignore`, and `x-cli-hidden` shape the corresponding
-argument or flag without changing the wire name unless the extension explicitly
-defines wire behavior in a future design.
+argument or flag without changing the wire name. Parameter-level
+`x-cli-completion` references a read-only operation from the same operation set
+and response selectors for API-backed shell completion.
+
+Completion providers are resolved by exact OpenAPI `operationId`. The provider
+must be unique, use `GET` or `HEAD`, and have no request body. Bindings use
+original `(in, name)` parameter identities and must cover every required
+provider parameter. Invalid providers are omitted with a deterministic warning;
+they do not remove the generated operation. Typed provider metadata is stored in
+the operation cache so command registration after `api sync` does not reparse
+the OpenAPI document.
 
 In tag layout, operations with a first tag are nested under that tag command;
 untagged operations remain directly under the API command. Flat layout remains

--- a/internal/cli/api_auth.go
+++ b/internal/cli/api_auth.go
@@ -676,7 +676,7 @@ func (c *CLI) applyOperationAuthInspectionStep(req *http.Request, s operationAut
 			return err
 		}
 	}
-	return s.handler.Authenticate(req.Context(), req, c.authContext(req.Context(), s.apiName, s.profileName, params, s.cacheKey, false))
+	return s.handler.Authenticate(req.Context(), req, c.authContext(req.Context(), s.apiName, s.profileName, params, s.cacheKey, false, false))
 }
 
 func (c *CLI) authInspectionRequest(cmd *cobra.Command, apiName, profileName string, resolved resolvedAuthConfig) (*http.Request, error) {
@@ -693,7 +693,7 @@ func (c *CLI) authInspectionRequest(cmd *cobra.Command, apiName, profileName str
 		return nil, err
 	}
 	req, _ := http.NewRequestWithContext(requestContext(cmd), "GET", "http://example.com", nil)
-	if err := handler.Authenticate(requestContext(cmd), req, c.authContext(requestContext(cmd), apiName, profileName, params, resolved.CacheKey, false)); err != nil {
+	if err := handler.Authenticate(requestContext(cmd), req, c.authContext(requestContext(cmd), apiName, profileName, params, resolved.CacheKey, false, false)); err != nil {
 		return nil, fmt.Errorf("building auth inspection: %w", err)
 	}
 	return req, nil

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -26,8 +27,9 @@ import (
 )
 
 type authHandlerOptions struct {
-	NoBrowser bool
-	Verbose   bool
+	NoBrowser      bool
+	Verbose        bool
+	NonInteractive bool
 }
 
 type authCallbacks struct {
@@ -67,8 +69,15 @@ func (c *CLI) authHandlerOptionsFromCmd(cmd *cobra.Command) (authHandlerOptions,
 func (c *CLI) authHandlerFor(ac *config.AuthConfig, opts authHandlerOptions) (auth.Handler, error) {
 	if c.customAuthHandlers != nil {
 		if h, ok := c.customAuthHandlers[ac.Type]; ok {
+			if opts.NonInteractive {
+				return nil, fmt.Errorf("custom auth handlers are not run during shell completion")
+			}
 			return h, nil
 		}
+	}
+	stderr := c.Stderr
+	if opts.NonInteractive {
+		stderr = io.Discard
 	}
 	switch ac.Type {
 	case "api-key":
@@ -86,9 +95,9 @@ func (c *CLI) authHandlerFor(ac *config.AuthConfig, opts authHandlerOptions) (au
 		return &authpkg.AuthorizationCode{
 			Cache:                auth.NewTokenCache(c.tokenCachePath()),
 			HTTPClient:           &http.Client{Transport: c.baseHTTPTransport()},
-			Stderr:               c.Stderr,
-			CanPrompt:            c.canPromptCode(),
-			NoBrowser:            opts.NoBrowser,
+			Stderr:               stderr,
+			CanPrompt:            !opts.NonInteractive && c.canPromptCode(),
+			NoBrowser:            opts.NoBrowser || opts.NonInteractive,
 			Verbose:              opts.Verbose,
 			CallbackSuccessColor: output.ThemeTokenColor("status_2xx"),
 			CallbackFailureColor: output.ThemeTokenColor("status_error"),
@@ -97,10 +106,13 @@ func (c *CLI) authHandlerFor(ac *config.AuthConfig, opts authHandlerOptions) (au
 		return &authpkg.DeviceCode{
 			Cache:      auth.NewTokenCache(c.tokenCachePath()),
 			HTTPClient: &http.Client{Transport: c.baseHTTPTransport()},
-			Stderr:     c.Stderr,
+			Stderr:     stderr,
 		}, nil
 	case "external-tool":
-		return &authpkg.ExternalTool{Stderr: c.Stderr}, nil
+		if opts.NonInteractive {
+			return nil, fmt.Errorf("external-tool auth is not run during shell completion")
+		}
+		return &authpkg.ExternalTool{Stderr: stderr}, nil
 	default:
 		return nil, fmt.Errorf("unknown auth type %q; supported: api-key, bearer, http-basic, oauth-client-credentials, oauth-authorization-code, oauth-device-code, external-tool", ac.Type)
 	}
@@ -130,8 +142,17 @@ func (c *CLI) authOnRequest(apiName, profileName string, prof *config.ProfileCon
 			}
 		}
 		callbacks.OnRequest = func(req *http.Request) error {
+			if handled, err := c.applyNonInteractiveOAuth(req, resolvedAuth.Config.Type, resolvedAuth.CacheKey, apiName, profileName, opts.NonInteractive); handled {
+				return err
+			}
 			if c.applyCachedOAuthClientCredentials(req, resolvedAuth.Config.Type, resolvedAuth.CacheKey, apiName, profileName, false) {
+				if opts.NonInteractive {
+					return nil
+				}
 				return c.runAuthHookPlugins(apiName, profileName, rawParams, secretKeys, req)
+			}
+			if err := rejectNonInteractiveCommandParams(rawParams, opts.NonInteractive); err != nil {
+				return err
 			}
 			params, err := c.buildAuthParams(rawParams)
 			if err != nil {
@@ -146,16 +167,19 @@ func (c *CLI) authOnRequest(apiName, profileName string, prof *config.ProfileCon
 				return err
 			}
 			preserveInsertedHeader := c.apiPreservesHeaderCase(apiName) && !authHeaderPresent(req.Header, resolvedAuth.Config.Type, params)
-			if err := handler.Authenticate(req.Context(), req, c.authContext(req.Context(), apiName, profileName, params, resolvedAuth.CacheKey, false)); err != nil {
+			if err := handler.Authenticate(req.Context(), req, c.authContext(req.Context(), apiName, profileName, params, resolvedAuth.CacheKey, false, opts.NonInteractive)); err != nil {
 				return err
 			}
 			if preserveInsertedHeader {
 				preserveAuthHeaderCase(req, resolvedAuth.Config.Type, params)
 			}
 			markAuthCredentialTargets(req, resolvedAuth.Config.Type, params)
+			if opts.NonInteractive {
+				return nil
+			}
 			return c.runAuthHookPlugins(apiName, profileName, rawParams, secretKeys, req)
 		}
-		if _, ok := handler.(auth.ForceCapable); ok {
+		if _, ok := handler.(auth.ForceCapable); ok && !opts.NonInteractive {
 			callbacks.OnUnauthorized = func(req *http.Request) error {
 				if c.applyCachedOAuthClientCredentials(req, resolvedAuth.Config.Type, resolvedAuth.CacheKey, apiName, profileName, true) {
 					return c.runAuthHookPlugins(apiName, profileName, rawParams, secretKeys, req)
@@ -173,7 +197,7 @@ func (c *CLI) authOnRequest(apiName, profileName string, prof *config.ProfileCon
 					return err
 				}
 				preserveInsertedHeader := c.apiPreservesHeaderCase(apiName) && !authHeaderPresent(req.Header, resolvedAuth.Config.Type, params)
-				if err := handler.Authenticate(req.Context(), req, c.authContext(req.Context(), apiName, profileName, params, resolvedAuth.CacheKey, true)); err != nil {
+				if err := handler.Authenticate(req.Context(), req, c.authContext(req.Context(), apiName, profileName, params, resolvedAuth.CacheKey, true, opts.NonInteractive)); err != nil {
 					return err
 				}
 				if preserveInsertedHeader {
@@ -187,6 +211,9 @@ func (c *CLI) authOnRequest(apiName, profileName string, prof *config.ProfileCon
 
 	// Auth hook plugins run even when no built-in auth is configured.
 	hookPlugins := c.pluginsByHook["auth"]
+	if opts.NonInteractive {
+		return callbacks
+	}
 	if callbacks.OnRequest == nil && len(hookPlugins) == 0 {
 		return callbacks
 	}
@@ -198,6 +225,32 @@ func (c *CLI) authOnRequest(apiName, profileName string, prof *config.ProfileCon
 		return c.runAuthHookPlugins(apiName, profileName, nil, nil, req)
 	}
 	return callbacks
+}
+
+func (c *CLI) applyNonInteractiveOAuth(req *http.Request, authType, cacheKey, apiName, profileName string, nonInteractive bool) (bool, error) {
+	if !nonInteractive || authType != "oauth-authorization-code" && authType != "oauth-device-code" {
+		return false, nil
+	}
+	token := c.cachedOAuthToken(authType, cacheKey, apiName, profileName)
+	if token == "" {
+		return true, fmt.Errorf("%s requires a cached unexpired access token during shell completion", authType)
+	}
+	if req.Header.Get("Authorization") == "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	return true, nil
+}
+
+func rejectNonInteractiveCommandParams(params map[string]string, nonInteractive bool) error {
+	if !nonInteractive {
+		return nil
+	}
+	for _, value := range params {
+		if strings.HasPrefix(value, "command:") {
+			return fmt.Errorf("command secret sources are not run during shell completion")
+		}
+	}
+	return nil
 }
 
 func (c *CLI) apiPreservesHeaderCase(apiName string) bool {
@@ -477,20 +530,26 @@ func (c *CLI) runSecretCommand(commandLine string) (string, error) {
 	return strings.TrimRight(string(out), "\r\n"), nil
 }
 
-func (c *CLI) authContext(ctx context.Context, apiName, profileName string, params map[string]string, cacheKey string, force bool) auth.AuthContext {
-	return auth.AuthContext{
+func (c *CLI) authContext(ctx context.Context, apiName, profileName string, params map[string]string, cacheKey string, force, nonInteractive bool) auth.AuthContext {
+	authContext := auth.AuthContext{
 		APIName:     apiName,
 		ProfileName: profileName,
 		BaseURL:     c.authBaseURL(apiName, profileName),
 		CacheKey:    cacheKey,
 		Params:      params,
 		TokenStore:  auth.NewTokenCache(c.tokenCachePath()),
-		Prompter:    cliPrompter{cli: c, ctx: ctx},
-		Stderr:      c.Stderr,
 		HTTPClient:  c.authHTTPClient(ctx),
-		Logger:      log.New(c.Stderr, "", 0),
 		Force:       force,
 	}
+	if nonInteractive {
+		authContext.Stderr = io.Discard
+		authContext.Logger = log.New(io.Discard, "", 0)
+	} else {
+		authContext.Prompter = cliPrompter{cli: c, ctx: ctx}
+		authContext.Stderr = c.Stderr
+		authContext.Logger = log.New(c.Stderr, "", 0)
+	}
+	return authContext
 }
 
 func (c *CLI) authBaseURL(apiName, profileName string) string {

--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
+
+	"github.com/rest-sh/restish/v2/config"
 )
 
 // enumSpec is an OpenAPI spec with a parameter that has enum values.
@@ -35,6 +38,117 @@ func enumSpec(baseURL string) string {
     }
   }
 }`, baseURL)
+}
+
+func dynamicCompletionSpec(baseURL string) string {
+	return fmt.Sprintf(`{
+  "openapi": "3.1.0",
+  "info": {"title": "Completion API", "version": "1"},
+  "servers": [{"url": %q}],
+  "paths": {
+    "/accounts": {"get": {"operationId": "listAccounts", "responses": {"200": {"description": "OK"}}}},
+    "/accounts/{account}/projects": {"get": {
+      "operationId": "listProjects",
+      "parameters": [{"name": "account", "in": "path", "required": true, "schema": {"type": "string"}}],
+      "responses": {"200": {"description": "OK"}}
+    }},
+	"/failures": {"get": {"operationId": "listFailures", "responses": {"200": {"description": "OK"}}}},
+	"/redirects": {"get": {"operationId": "listRedirects", "responses": {"200": {"description": "OK"}}}},
+    "/accounts/{account}/servers": {"get": {
+      "operationId": "listServers",
+      "parameters": [
+        {"name": "account", "in": "path", "required": true, "schema": {"type": "string"},
+         "x-cli-completion": {"operation_id": "listAccounts", "value_path": "body.items.id", "description_path": "body.items.name"}},
+		{"name": "project", "in": "query", "schema": {"type": "string"},
+		 "x-cli-completion": {"operation_id": "listProjects", "bindings": {"path.account": "path.account"}, "value_path": "body.items.id", "description_path": "body.items.name"}},
+		{"name": "mode", "in": "query", "schema": {"type": "string", "enum": ["active"]},
+		 "x-cli-completion": {"operation_id": "listAccounts", "value_path": "body.items.id"}},
+		{"name": "failure", "in": "query", "schema": {"type": "string"},
+		 "x-cli-completion": {"operation_id": "listFailures", "value_path": "body.items.id"}},
+		{"name": "redirect", "in": "query", "schema": {"type": "string"},
+		 "x-cli-completion": {"operation_id": "listRedirects", "value_path": "body.items.id"}}
+      ],
+      "responses": {"200": {"description": "OK"}}
+    }}
+  }
+}`, baseURL)
+}
+
+func TestDynamicParameterCompletionAfterAPISync(t *testing.T) {
+	var requests atomic.Int32
+	var failures atomic.Int32
+	var redirects atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/accounts", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Completion-Test") != "yes" {
+			t.Errorf("missing profile header")
+		}
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"items":[{"id":"acct-1","name":"Primary Account"}]}`)
+	})
+	mux.HandleFunc("/accounts/acct-1/projects", func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Link", "</next>; rel=next")
+		fmt.Fprint(w, `{"items":[{"id":"prod","name":"Production\tWest"},{"id":"preview","name":"Preview"},{"id":"bad\n:0","name":"Bad"}]}`)
+	})
+	mux.HandleFunc("/failures", func(w http.ResponseWriter, r *http.Request) {
+		failures.Add(1)
+		http.Error(w, "try later", http.StatusServiceUnavailable)
+	})
+	mux.HandleFunc("/redirects", func(w http.ResponseWriter, r *http.Request) {
+		redirects.Add(1)
+		http.Redirect(w, r, "/accounts", http.StatusFound)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	env := setupEnvWithSpec(t, mux, dynamicCompletionSpec)
+	requests.Store(0)
+	baseURL := env.baseURL(t)
+	env.writeAPIConfig(t, &config.APIConfig{BaseURL: baseURL, Profiles: map[string]*config.ProfileConfig{
+		"default": {Headers: []string{"X-Completion-Test: yes"}},
+	}})
+
+	for _, test := range []struct {
+		args []string
+		want string
+	}{
+		{[]string{"restish", "__complete", "tapi", "list-servers", "ac"}, "acct-1\tPrimary Account"},
+		{[]string{"restish", "__complete", "tapi", "list-servers", "acct-1", "--project", "pr"}, "prod\tProduction West"},
+		{[]string{"restish", "__complete", "tapi", "list-servers", "acct-1", "--mode", "a"}, "active"},
+	} {
+		cli, out := env.newCaptureCLI()
+		if err := cli.Run(test.args); err != nil {
+			t.Fatalf("completion: %v", err)
+		}
+		if got := out.String(); !strings.Contains(got, test.want) || strings.Contains(got, "bad\n:0") {
+			t.Fatalf("completion output = %q, requests = %d", got, requests.Load())
+		}
+	}
+	cli, out := env.newCaptureCLI()
+	if err := cli.Run([]string{"restish", "__complete", "tapi", "list-servers", "acct-1", "--project", "pr"}); err != nil {
+		t.Fatalf("cached completion: %v", err)
+	}
+	if !strings.Contains(out.String(), "prod\tProduction West") {
+		t.Fatalf("cached completion output = %q", out.String())
+	}
+	cli, out = env.newCaptureCLI()
+	if err := cli.Run([]string{"restish", "__complete", "tapi", "list-servers", "acct-1", "--failure", ""}); err != nil {
+		t.Fatalf("failed completion: %v", err)
+	}
+	if failures.Load() != 1 || strings.Contains(out.String(), "try later") {
+		t.Fatalf("failed completion output = %q, requests = %d", out.String(), failures.Load())
+	}
+	cli, out = env.newCaptureCLI()
+	if err := cli.Run([]string{"restish", "__complete", "tapi", "list-servers", "acct-1", "--redirect", ""}); err != nil {
+		t.Fatalf("redirect completion: %v", err)
+	}
+	if redirects.Load() != 1 || strings.Contains(out.String(), "acct-1") {
+		t.Fatalf("redirect completion output = %q, requests = %d", out.String(), redirects.Load())
+	}
+	if requests.Load() != 2 {
+		t.Fatalf("provider requests = %d", requests.Load())
+	}
 }
 
 // TestEnumFlagCompletion verifies that OpenAPI enum values are registered as

--- a/internal/cli/generated.go
+++ b/internal/cli/generated.go
@@ -70,6 +70,12 @@ func (c *CLI) buildAPICommandFromOperationSet(apiName string, apiCfg *config.API
 	for _, warning := range set.Warnings {
 		c.generatedWarnf("API %q: %s", apiName, warning)
 	}
+	operationsByID := map[string]spec.Operation{}
+	for _, op := range ops {
+		if op.ID != "" {
+			operationsByID[op.ID] = op
+		}
+	}
 
 	long := strings.TrimSpace(set.Info.Description)
 	if long == "" {
@@ -129,7 +135,7 @@ func (c *CLI) buildAPICommandFromOperationSet(apiName string, apiCfg *config.API
 				examplePrefix = apiName + " " + tagCommandName
 			}
 		}
-		cmd, err := c.buildOperationCommand(apiName, examplePrefix, op, operationBase)
+		cmd, err := c.buildOperationCommandWithProviders(apiName, examplePrefix, op, operationBase, operationsByID)
 		if err != nil {
 			c.generatedWarnf("skipping %s %s for API %q: %v", op.Method, op.Path, apiName, err)
 			continue
@@ -328,6 +334,7 @@ type paramInfo struct {
 	allowReserved    bool
 	contentMediaType string
 	enum             []string // allowed values from OpenAPI schema enum, if present
+	completion       *spec.ParamCompletion
 	objectProperties []spec.ParamObjectProperty
 	parent           *paramInfo
 	objectKey        string
@@ -338,6 +345,10 @@ type paramInfo struct {
 // operationBase, when non-empty, is removed from fallback command names derived
 // from paths. It does not affect explicit operationId or x-cli-name values.
 func (c *CLI) buildOperationCommand(apiName, examplePrefix string, op spec.Operation, operationBase string) (*cobra.Command, error) {
+	return c.buildOperationCommandWithProviders(apiName, examplePrefix, op, operationBase, nil)
+}
+
+func (c *CLI) buildOperationCommandWithProviders(apiName, examplePrefix string, op spec.Operation, operationBase string, operationsByID map[string]spec.Operation) (*cobra.Command, error) {
 	cmdName := operationCommandName(op, operationBase)
 
 	// Build param lists, honouring per-parameter x-cli-name / x-cli-description.
@@ -389,6 +400,7 @@ func (c *CLI) buildOperationCommand(apiName, examplePrefix string, op spec.Opera
 			allowReserved:    p.AllowReserved,
 			contentMediaType: p.ContentMediaType,
 			enum:             p.Enum,
+			completion:       p.XCLI.Completion,
 			objectProperties: p.ObjectProperties,
 		}
 	}
@@ -542,6 +554,11 @@ func (c *CLI) buildOperationCommand(apiName, examplePrefix string, op spec.Opera
 			_ = cmd.RegisterFlagCompletionFunc(p.flagName, func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 				return vals, cobra.ShellCompDirectiveNoFileComp
 			})
+		} else if p.completion != nil {
+			param := p
+			_ = cmd.RegisterFlagCompletionFunc(p.flagName, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+				return c.completeGeneratedParam(cmd, args, toComplete, apiName, param, required, optional, operationsByID)
+			})
 		}
 	}
 
@@ -549,10 +566,13 @@ func (c *CLI) buildOperationCommand(apiName, examplePrefix string, op spec.Opera
 	// Cobra uses ValidArgsFunction for the first positional arg completion.
 	if len(required) > 0 {
 		reqWithEnum := required // capture
-		cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+		cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			idx := len(args)
 			if idx < len(reqWithEnum) && len(reqWithEnum[idx].enum) > 0 {
 				return reqWithEnum[idx].enum, cobra.ShellCompDirectiveNoFileComp
+			}
+			if idx < len(reqWithEnum) && reqWithEnum[idx].completion != nil {
+				return c.completeGeneratedParam(cmd, args, toComplete, apiName, reqWithEnum[idx], required, optional, operationsByID)
 			}
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -1449,35 +1469,9 @@ func (c *CLI) runGeneratedOp(
 		}
 	}
 
-	// Build the raw URL. When operation_base is set, resolve its absolute path
-	// against base_url using v1 semantics so generated operations can escape a
-	// base URL sub-path.
-	var rawURL string
-	baseURL, operationBase := c.generatedOperationBase(cmd, apiName)
-	if operationServer != "" {
-		apiCfg, err := c.requireAPI(apiName)
-		if err != nil {
-			return err
-		}
-		rawURL = strings.TrimRight(operationServer, "/") + path
-		_, rewritten, err := config.ApplyURLOverrides(rawURL, effectiveURLOverrides(apiCfg, c.profileFromCmd(cmd)))
-		if err != nil {
-			return fmt.Errorf("url_overrides: %w", err)
-		}
-		if !rewritten && !config.OperationOriginAllowed(operationServer, apiCfg.AllowedOperationOrigins) {
-			return fmt.Errorf("operation server %s is outside API base_url and is not allowed; add allowed_operation_origins[]: %s", operationServerOrigin(operationServer), suggestedOperationOrigin(operationServer))
-		}
-	} else if operationBase != "" {
-		resolvedBase, err := config.ResolveOperationBaseURL(baseURL, operationBase)
-		if err != nil {
-			return fmt.Errorf("operation_base: %w", err)
-		}
-		rawURL = strings.TrimRight(resolvedBase, "/") + path
-	} else {
-		rawURL = apiName + path
-	}
-	if qs := encodeGeneratedQuery(query); qs != "" {
-		rawURL += "?" + qs
+	rawURL, err := c.generatedOperationURL(apiName, c.profileFromCmd(cmd), path, operationServer, query)
+	if err != nil {
+		return err
 	}
 
 	bodyArgs := args[bodyArgStart:]
@@ -1633,23 +1627,36 @@ func generatedScalarTypeLabel(typ string) string {
 	}
 }
 
-func (c *CLI) generatedOperationBase(cmd *cobra.Command, apiName string) (string, string) {
-	if c == nil || c.cfg == nil || c.cfg.APIs == nil || c.cfg.APIs[apiName] == nil {
-		return "", ""
+func (c *CLI) generatedOperationURL(apiName, profileName, path, operationServer string, query []generatedQueryParam) (string, error) {
+	apiCfg, err := c.requireAPI(apiName)
+	if err != nil {
+		return "", err
 	}
-	apiCfg := c.cfg.APIs[apiName]
-	baseURL := apiCfg.BaseURL
-	operationBase := apiCfg.OperationBase
-	profileName := c.profileFromCmd(cmd)
-	if prof := profileForName(apiCfg, profileName); prof != nil {
-		if prof.BaseURL != "" {
-			baseURL = prof.BaseURL
+	var rawURL string
+	baseURL := effectiveProfileBaseURL(apiCfg, profileName)
+	operationBase := effectiveOperationBase(apiCfg, profileName)
+	if operationServer != "" {
+		rawURL = strings.TrimRight(operationServer, "/") + path
+		_, rewritten, err := config.ApplyURLOverrides(rawURL, effectiveURLOverrides(apiCfg, profileName))
+		if err != nil {
+			return "", fmt.Errorf("url_overrides: %w", err)
 		}
-		if prof.OperationBase != "" {
-			operationBase = prof.OperationBase
+		if !rewritten && !config.OperationOriginAllowed(operationServer, apiCfg.AllowedOperationOrigins) {
+			return "", fmt.Errorf("operation server %s is outside API base_url and is not allowed; add allowed_operation_origins[]: %s", operationServerOrigin(operationServer), suggestedOperationOrigin(operationServer))
 		}
+	} else if operationBase != "" {
+		resolvedBase, err := config.ResolveOperationBaseURL(baseURL, operationBase)
+		if err != nil {
+			return "", fmt.Errorf("operation_base: %w", err)
+		}
+		rawURL = strings.TrimRight(resolvedBase, "/") + path
+	} else {
+		rawURL = apiName + path
 	}
-	return baseURL, operationBase
+	if qs := encodeGeneratedQuery(query); qs != "" {
+		rawURL += "?" + qs
+	}
+	return rawURL, nil
 }
 
 func operationServerOrigin(raw string) string {

--- a/internal/cli/generated_completion.go
+++ b/internal/cli/generated_completion.go
@@ -1,0 +1,429 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/rest-sh/restish/v2/internal/content"
+	"github.com/rest-sh/restish/v2/internal/output"
+	"github.com/rest-sh/restish/v2/internal/request"
+	"github.com/rest-sh/restish/v2/internal/spec"
+	"github.com/spf13/cobra"
+)
+
+const (
+	generatedCompletionTimeout       = 2 * time.Second
+	generatedCompletionMaxBodyBytes  = 1 << 20
+	generatedCompletionMaxCandidates = 100
+	generatedCompletionMaxValueBytes = 256
+)
+
+func (c *CLI) completeGeneratedParam(cmd *cobra.Command, args []string, toComplete, apiName string, parameter *paramInfo, required, optional []*paramInfo, operations map[string]spec.Operation) ([]string, cobra.ShellCompDirective) {
+	ctx, cancel := context.WithTimeout(cmd.Context(), generatedCompletionTimeout)
+	defer cancel()
+	candidates, err := c.generatedParamCandidates(ctx, cmd, args, toComplete, apiName, parameter, required, optional, operations)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	return candidates, cobra.ShellCompDirectiveNoFileComp
+}
+
+func (c *CLI) generatedParamCandidates(ctx context.Context, cmd *cobra.Command, args []string, toComplete, apiName string, parameter *paramInfo, required, optional []*paramInfo, operations map[string]spec.Operation) ([]string, error) {
+	if parameter == nil || parameter.completion == nil {
+		return nil, nil
+	}
+	provider, ok := operations[parameter.completion.OperationID]
+	if !ok || provider.Method != http.MethodGet && provider.Method != http.MethodHead || provider.HasBody {
+		return nil, nil
+	}
+	values, err := generatedCompletionSourceValues(cmd, args, parameter, required, optional)
+	if err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	path, query, headers := provider.Path, []generatedQueryParam{}, []string{}
+	providerParams := completionProviderParams(provider)
+	bindings := make([]string, 0, len(parameter.completion.Bindings))
+	for target := range parameter.completion.Bindings {
+		bindings = append(bindings, target)
+	}
+	sort.Strings(bindings)
+	for _, target := range bindings {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		source := parameter.completion.Bindings[target]
+		bound, exists := values[completionRefKey(source)]
+		providerParam := providerParams[completionRefKey(target)]
+		if !exists || providerParam == nil {
+			return nil, nil
+		}
+		if err := validateGeneratedParamValues(providerParam, bound, target); err != nil {
+			return nil, err
+		}
+		path, query, headers, err = addGeneratedParam(path, query, headers, providerParam, bound)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if pathParamRe.MatchString(path) {
+		return nil, nil
+	}
+	profileName := completionProfileName(cmd)
+	rawURL, err := c.generatedOperationURL(apiName, profileName, path, provider.OperationServer, query)
+	if err != nil {
+		return nil, err
+	}
+	return c.fetchGeneratedCompletion(ctx, cmd, rawURL, apiName, profileName, toComplete, headers, provider, *parameter.completion)
+}
+
+func completionRefKey(value string) string {
+	location, name, _ := strings.Cut(value, ".")
+	return paramKey(location, name)
+}
+
+func generatedCompletionSourceValues(cmd *cobra.Command, args []string, completing *paramInfo, required, optional []*paramInfo) (map[string][]string, error) {
+	values := map[string][]string{}
+	for i, parameter := range required {
+		if i >= len(args) {
+			break
+		}
+		values[paramKey(parameter.in, parameter.name)] = []string{args[i]}
+	}
+	for _, parameter := range optional {
+		if parameter == completing || parameter.parent != nil || !cmd.Flags().Changed(parameter.flagName) {
+			continue
+		}
+		value, err := generatedFlagValues(cmd, parameter)
+		if err != nil {
+			return nil, err
+		}
+		values[paramKey(parameter.in, parameter.name)] = value
+	}
+	return values, nil
+}
+
+func completionProviderParams(operation spec.Operation) map[string]*paramInfo {
+	parameters := map[string]*paramInfo{}
+	for _, parameter := range operation.Parameters {
+		if parameter.XCLI.Ignore {
+			continue
+		}
+		parameters[paramKey(parameter.In, parameter.Name)] = &paramInfo{
+			name: parameter.Name, in: parameter.In, required: parameter.Required,
+			typ: parameter.Type, itemType: parameter.ItemType, style: parameter.Style,
+			explode: parameter.Explode, allowReserved: parameter.AllowReserved,
+			contentMediaType: parameter.ContentMediaType,
+		}
+	}
+	return parameters
+}
+
+func (c *CLI) fetchGeneratedCompletion(ctx context.Context, cmd *cobra.Command, rawURL, apiName, profileName, toComplete string, headers []string, provider spec.Operation, completion spec.ParamCompletion) ([]string, error) {
+	gf, err := parseGlobalFlags(cmd)
+	if err != nil {
+		return nil, err
+	}
+	cacheKey := strings.Join([]string{
+		provider.Method, provider.ID, rawURL, strings.Join(headers, "\x00"),
+		completion.ValuePath, completion.DescriptionPath, toComplete,
+		c.generatedCompletionConfigKey(apiName, gf),
+		generatedCompletionProviderKey(provider),
+	}, "\x00")
+	opts, err := c.httpOptsFromGlobalFlags(gf, true)
+	if err != nil {
+		return nil, err
+	}
+	opts.Timeout = generatedCompletionTimeout
+	opts.Retry = 0
+	opts.RetryUnsafe = false
+	opts.NoCache = true
+	opts.Logger = nil
+	opts.OnBeforeRequest = nil
+	opts.OnResponse = nil
+	opts.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	completionContent := generatedCompletionContentRegistry()
+	opts.AcceptHeader = completionContent.AcceptHeader()
+	opts.AcceptEncodingHeader = completionContent.AcceptEncodingHeader()
+	mediaTypes := provider.ResponseMediaTypes
+	if len(mediaTypes) == 0 && provider.ResponseMediaType != "" {
+		mediaTypes = []string{provider.ResponseMediaType}
+	}
+	if accept := completionContent.AcceptHeaderFor(mediaTypes); accept != "" {
+		opts.AcceptHeader = accept
+	}
+	prepared, err := c.prepareRequest(ctx, provider.Method, rawURL, profileName, opts, nil, headers, provider.NoAuth, authHandlerOptions{NoBrowser: true, NonInteractive: true}, &operationAuthPolicy{
+		OptionalAuth: provider.OptionalAuth, NoAuth: provider.NoAuth,
+		CredentialAlternatives: provider.CredentialAlternatives, Override: gf.Auth,
+	}, false, apiName)
+	if err != nil {
+		return nil, err
+	}
+	defer c.closePreparedTransport(prepared)
+	cacheAllowed := !gf.NoCache && !prepared.authEnabled && prepared.opts.ClientCertPath == "" && prepared.opts.ClientKeyPath == ""
+	if cacheAllowed {
+		if candidates, ok := c.loadGeneratedCompletionCache(apiName, profileName, cacheKey); ok {
+			return candidates, nil
+		}
+	}
+	prepared.opts.OnUnauthorized = nil
+	response, err := request.Do(ctx, provider.Method, prepared.rawURL, nil, prepared.opts)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		_ = response.Body.Close()
+		return nil, fmt.Errorf("completion provider returned HTTP %d", response.StatusCode)
+	}
+	normalized, err := output.Normalize(response, completionContent, generatedCompletionMaxBodyBytes)
+	if err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	doc := normalizedResponseDoc(normalized)
+	value, err := selectGeneratedCompletionValue(ctx, doc, completion.ValuePath)
+	if err != nil {
+		return nil, err
+	}
+	var descriptions any
+	if completion.DescriptionPath != "" {
+		descriptions, err = selectGeneratedCompletionValue(ctx, doc, completion.DescriptionPath)
+		if err != nil {
+			return nil, err
+		}
+		if descriptions == nil {
+			return nil, fmt.Errorf("completion description path returned null")
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	candidates, err := generatedCompletionCandidatesContext(ctx, value, descriptions, toComplete)
+	if err != nil {
+		return nil, err
+	}
+	if cacheAllowed {
+		c.storeGeneratedCompletionCache(apiName, profileName, cacheKey, candidates)
+	}
+	return candidates, nil
+}
+
+func generatedCompletionContentRegistry() *content.Registry {
+	registry := content.Default()
+	registry.AddContentType(&content.ContentType{
+		Name: "completion-json", MIMETypes: []string{"application/json"}, Suffixes: []string{"+json"}, Quality: 0.9,
+		Marshal: json.Marshal,
+		Unmarshal: func(data []byte) (any, error) {
+			decoder := json.NewDecoder(bytes.NewReader(data))
+			decoder.UseNumber()
+			var value any
+			if err := decoder.Decode(&value); err != nil {
+				return nil, err
+			}
+			if err := decoder.Decode(&struct{}{}); err != io.EOF {
+				return nil, fmt.Errorf("invalid trailing JSON data")
+			}
+			return value, nil
+		},
+	})
+	return registry
+}
+
+func selectGeneratedCompletionValue(ctx context.Context, value any, path string) (any, error) {
+	parts := strings.Split(path, ".")
+	current := []any{value}
+	for partIndex, part := range parts {
+		next := make([]any, 0, len(current))
+		for i, item := range current {
+			if i%128 == 0 {
+				if err := ctx.Err(); err != nil {
+					return nil, err
+				}
+			}
+			if list, ok := item.([]any); ok {
+				for j, entry := range list {
+					if j%128 == 0 {
+						if err := ctx.Err(); err != nil {
+							return nil, err
+						}
+					}
+					if selected, found := completionField(entry, part, completionHeaderField(parts, partIndex)); found {
+						next = append(next, selected)
+					}
+				}
+				continue
+			}
+			if selected, found := completionField(item, part, completionHeaderField(parts, partIndex)); found {
+				next = append(next, selected)
+			}
+		}
+		if len(next) == 0 {
+			return nil, fmt.Errorf("completion path %q was not found", path)
+		}
+		current = next
+	}
+	if len(current) == 1 {
+		return current[0], nil
+	}
+	return current, nil
+}
+
+func completionHeaderField(parts []string, index int) bool {
+	return index == 1 && (parts[0] == "headers" || parts[0] == "headers_all")
+}
+
+func completionField(value any, name string, caseInsensitive bool) (any, bool) {
+	switch value := value.(type) {
+	case map[string]any:
+		selected, ok := value[name]
+		if ok || !caseInsensitive {
+			return selected, ok
+		}
+		for key, selected := range value {
+			if strings.EqualFold(key, name) {
+				return selected, true
+			}
+		}
+	case map[string]string:
+		selected, ok := value[name]
+		if ok || !caseInsensitive {
+			return selected, ok
+		}
+		for key, selected := range value {
+			if strings.EqualFold(key, name) {
+				return selected, true
+			}
+		}
+	}
+	return nil, false
+}
+
+func generatedCompletionCandidates(value, descriptions any, prefix string) ([]string, error) {
+	return generatedCompletionCandidatesContext(context.Background(), value, descriptions, prefix)
+}
+
+func generatedCompletionCandidatesContext(ctx context.Context, value, descriptions any, prefix string) ([]string, error) {
+	values, err := completionScalars(ctx, value)
+	if err != nil {
+		return nil, err
+	}
+	var labels []string
+	if descriptions != nil {
+		labels, err = completionScalars(ctx, descriptions)
+		if err != nil || len(labels) != len(values) {
+			return nil, fmt.Errorf("completion descriptions do not match values")
+		}
+	}
+	seen := map[string]bool{}
+	result := make([]string, 0, min(len(values), generatedCompletionMaxCandidates))
+	for i, value := range values {
+		if i%128 == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
+		if !safeCompletionValue(value) || !strings.HasPrefix(value, prefix) || seen[value] {
+			continue
+		}
+		seen[value] = true
+		candidate := value
+		if len(labels) > 0 {
+			candidate = string(cobra.CompletionWithDesc(value, sanitizeCompletionDescription(labels[i])))
+		}
+		result = append(result, candidate)
+		if len(result) == generatedCompletionMaxCandidates {
+			break
+		}
+	}
+	return result, nil
+}
+
+func completionScalars(ctx context.Context, value any) ([]string, error) {
+	item := reflect.ValueOf(value)
+	for item.IsValid() && (item.Kind() == reflect.Interface || item.Kind() == reflect.Pointer) {
+		if item.IsNil() {
+			return nil, fmt.Errorf("completion value is null")
+		}
+		item = item.Elem()
+	}
+	if !item.IsValid() {
+		return nil, fmt.Errorf("completion value is null")
+	}
+	if item.Kind() != reflect.Array && item.Kind() != reflect.Slice {
+		value, err := completionScalar(item)
+		return []string{value}, err
+	}
+	values := make([]string, 0, min(item.Len(), generatedCompletionMaxCandidates))
+	for i := 0; i < item.Len(); i++ {
+		if i%128 == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
+		value, err := completionScalar(item.Index(i))
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, value)
+	}
+	return values, nil
+}
+
+func completionScalar(value reflect.Value) (string, error) {
+	for value.IsValid() && (value.Kind() == reflect.Interface || value.Kind() == reflect.Pointer) {
+		if value.IsNil() {
+			return "", fmt.Errorf("completion value is null")
+		}
+		value = value.Elem()
+	}
+	switch value.Kind() {
+	case reflect.String, reflect.Bool,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return fmt.Sprint(value.Interface()), nil
+	default:
+		return "", fmt.Errorf("completion value must be a scalar")
+	}
+}
+
+func safeCompletionValue(value string) bool {
+	if value == "" || strings.TrimSpace(value) != value || strings.HasPrefix(value, "_activeHelp_ ") || len(value) > generatedCompletionMaxValueBytes || !utf8.ValidString(value) {
+		return false
+	}
+	for _, r := range value {
+		if unicode.IsControl(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func sanitizeCompletionDescription(value string) string {
+	value = strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) || unicode.IsSpace(r) {
+			return ' '
+		}
+		return r
+	}, value)
+	value = strings.Join(strings.Fields(value), " ")
+	for len(value) > generatedCompletionMaxValueBytes {
+		_, size := utf8.DecodeLastRuneInString(value)
+		value = value[:len(value)-size]
+	}
+	return value
+}

--- a/internal/cli/generated_completion_auth_internal_test.go
+++ b/internal/cli/generated_completion_auth_internal_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/rest-sh/restish/v2/config"
+	"github.com/rest-sh/restish/v2/internal/request"
+)
+
+func TestCompletionRejectsExternalToolAuth(t *testing.T) {
+	cli := New()
+	_, err := cli.authHandlerFor(&config.AuthConfig{Type: "external-tool"}, authHandlerOptions{NonInteractive: true})
+	if err == nil {
+		t.Fatal("external-tool auth accepted during shell completion")
+	}
+}
+
+func TestExplicitAPIIdentityWinsForOperationServer(t *testing.T) {
+	cli := New()
+	cli.cfg = &config.Config{APIs: map[string]*config.APIConfig{
+		"source": {BaseURL: "https://source.example", Profiles: map[string]*config.ProfileConfig{"default": {Headers: []string{"X-Source: yes"}}}},
+		"other":  {BaseURL: "https://other.example", Profiles: map[string]*config.ProfileConfig{"default": {Headers: []string{"X-Other: no"}}}},
+	}}
+	prepared, err := cli.prepareRequest(context.Background(), http.MethodGet, "https://other.example/items", "default", request.Options{NoCache: true}, nil, nil, true, authHandlerOptions{NonInteractive: true}, &operationAuthPolicy{NoAuth: true}, false, "source")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cli.closePreparedTransport(prepared)
+	if prepared.apiName != "source" || len(prepared.opts.Headers) != 1 || prepared.opts.Headers[0] != "X-Source: yes" {
+		t.Fatalf("prepared API = %q, headers = %#v", prepared.apiName, prepared.opts.Headers)
+	}
+}
+
+func TestCompletionProfileAuthIsNonInteractive(t *testing.T) {
+	cli := New()
+	for _, authConfig := range []*config.AuthConfig{
+		{Type: "bearer", Params: map[string]string{"token": "command:get-token"}},
+		{Type: "oauth-device-code", Params: map[string]string{"client_id": "client"}},
+	} {
+		callbacks := cli.authOnRequest("api", "default", &config.ProfileConfig{Auth: authConfig}, authHandlerOptions{NonInteractive: true})
+		request, _ := http.NewRequest(http.MethodGet, "https://example.com", nil)
+		if callbacks.OnRequest == nil || callbacks.OnRequest(request) == nil {
+			t.Fatalf("auth type %q was allowed to start interactively", authConfig.Type)
+		}
+	}
+}
+
+func TestCompletionRejectsCommandSecretSources(t *testing.T) {
+	if err := rejectNonInteractiveCommandParams(map[string]string{"token": "command:get-token"}, true); err == nil {
+		t.Fatal("command secret source accepted during shell completion")
+	}
+}

--- a/internal/cli/generated_completion_cache.go
+++ b/internal/cli/generated_completion_cache.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	diskcache "github.com/rest-sh/restish/v2/internal/cache"
+	"github.com/rest-sh/restish/v2/internal/spec"
+)
+
+const (
+	generatedCompletionCacheTTL      = 30 * time.Second
+	generatedCompletionCacheMaxBytes = 1 << 20
+)
+
+type generatedCompletionCacheEntry struct {
+	ExpiresAt  time.Time `json:"expires_at"`
+	Candidates []string  `json:"candidates"`
+}
+
+func (c *CLI) loadGeneratedCompletionCache(apiName, profileName, key string) ([]string, bool) {
+	cache, err := c.generatedCompletionDiskCache(apiName, profileName)
+	if err != nil {
+		return nil, false
+	}
+	storageKey := "https://completion.invalid/" + generatedCompletionCacheKey(key)
+	data, ok := cache.Get(storageKey)
+	if !ok || len(data) > generatedCompletionCacheMaxBytes {
+		return nil, false
+	}
+	var entry generatedCompletionCacheEntry
+	if json.Unmarshal(data, &entry) != nil || time.Now().After(entry.ExpiresAt) || len(entry.Candidates) > generatedCompletionMaxCandidates {
+		cache.Delete(storageKey)
+		return nil, false
+	}
+	candidates := make([]string, 0, len(entry.Candidates))
+	for _, candidate := range entry.Candidates {
+		value, description, hasDescription := strings.Cut(candidate, "\t")
+		if !safeCompletionValue(value) {
+			return nil, false
+		}
+		if hasDescription {
+			candidate = value + "\t" + sanitizeCompletionDescription(description)
+		}
+		candidates = append(candidates, candidate)
+	}
+	return candidates, true
+}
+
+func (c *CLI) storeGeneratedCompletionCache(apiName, profileName, key string, candidates []string) {
+	cache, err := c.generatedCompletionDiskCache(apiName, profileName)
+	if err != nil {
+		return
+	}
+	data, err := json.Marshal(generatedCompletionCacheEntry{
+		ExpiresAt: time.Now().Add(generatedCompletionCacheTTL), Candidates: candidates,
+	})
+	if err == nil && len(data) <= generatedCompletionCacheMaxBytes {
+		cache.Set("https://completion.invalid/"+generatedCompletionCacheKey(key), data)
+	}
+}
+
+func (c *CLI) generatedCompletionDiskCache(apiName, profileName string) (*diskcache.DiskCache, error) {
+	maxBytes, err := c.cacheMaxBytes()
+	if err != nil {
+		return nil, err
+	}
+	if maxBytes <= 0 {
+		maxBytes = diskcache.DefaultMaxBytes
+	}
+	return diskcache.New(c.cacheDir(), maxBytes, c.apiCacheNamespace(apiName, profileName))
+}
+
+func generatedCompletionCacheKey(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return fmt.Sprintf("%x", sum)
+}
+
+func (c *CLI) generatedCompletionConfigKey(apiName string, flags GlobalFlags) string {
+	var api any
+	var authProfiles any
+	if c.cfg != nil && c.cfg.APIs != nil {
+		api = c.cfg.APIs[apiName]
+		authProfiles = c.cfg.AuthProfiles
+	}
+	data, _ := json.Marshal(struct {
+		API          any
+		AuthProfiles any
+		Flags        GlobalFlags
+	}{api, authProfiles, flags})
+	return generatedCompletionCacheKey(string(data))
+}
+
+func generatedCompletionProviderKey(provider spec.Operation) string {
+	data, _ := json.Marshal(struct {
+		NoAuth                 bool
+		OptionalAuth           bool
+		CredentialAlternatives []spec.CredentialAlternative
+	}{provider.NoAuth, provider.OptionalAuth, provider.CredentialAlternatives})
+	return generatedCompletionCacheKey(string(data))
+}

--- a/internal/cli/generated_completion_internal_test.go
+++ b/internal/cli/generated_completion_internal_test.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestGeneratedCompletionCandidates(t *testing.T) {
+	values := []any{"prod", "prod", "preview", "bad\n:0", strings.Repeat("x", generatedCompletionMaxValueBytes+1)}
+	descriptions := []any{"Production\tWest", "duplicate", "Preview", "bad", "long"}
+	got, err := generatedCompletionCandidates(values, descriptions, "pr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"prod\tProduction West", "preview\tPreview"}
+	if len(got) != len(want) {
+		t.Fatalf("candidates = %#v", got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("candidates = %#v", got)
+		}
+	}
+}
+
+func TestGeneratedCompletionSelector(t *testing.T) {
+	doc := map[string]any{"body": map[string]any{"items": []any{map[string]any{"id": "acct-1"}}}}
+	got, err := selectGeneratedCompletionValue(context.Background(), doc, "body.items.id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "acct-1" {
+		t.Fatalf("selector = %#v (%T)", got, got)
+	}
+}
+
+func TestGeneratedCompletionHeaderSelectorIsCaseInsensitive(t *testing.T) {
+	doc := map[string]any{"headers": map[string]any{"X-Request-Id": "req-1"}}
+	got, err := selectGeneratedCompletionValue(context.Background(), doc, "headers.X-Request-ID")
+	if err != nil || got != "req-1" {
+		t.Fatalf("selector = %#v, %v", got, err)
+	}
+}
+
+func TestGeneratedCompletionPreservesJSONNumbers(t *testing.T) {
+	decoded, err := generatedCompletionContentRegistry().Decode("application/json", []byte(`{"id":9007199254740993}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	value, err := selectGeneratedCompletionValue(context.Background(), map[string]any{"body": decoded}, "body.id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidates, err := generatedCompletionCandidates(value, nil, "")
+	if err != nil || len(candidates) != 1 || candidates[0] != "9007199254740993" {
+		t.Fatalf("candidates = %#v, %v", candidates, err)
+	}
+}
+
+func TestGeneratedCompletionCandidatesRequireMatchingDescriptions(t *testing.T) {
+	if _, err := generatedCompletionCandidates([]any{"one", "two"}, []any{"One"}, ""); err == nil {
+		t.Fatal("mismatched descriptions accepted")
+	}
+}
+
+func TestGeneratedCompletionCandidatesFilterBeforeLimit(t *testing.T) {
+	values := make([]any, generatedCompletionMaxCandidates+1)
+	for i := range values {
+		values[i] = "other"
+	}
+	values[len(values)-1] = "prod"
+	got, err := generatedCompletionCandidates(values, nil, "prod")
+	if err != nil || len(got) != 1 || got[0] != "prod" {
+		t.Fatalf("candidates = %#v, %v", got, err)
+	}
+}
+
+func TestGeneratedCompletionRejectsShellControlValues(t *testing.T) {
+	for _, value := range []string{"_activeHelp_ injected", " leading", "trailing "} {
+		if safeCompletionValue(value) {
+			t.Fatalf("unsafe completion value %q accepted", value)
+		}
+	}
+}

--- a/internal/cli/generated_test.go
+++ b/internal/cli/generated_test.go
@@ -5438,6 +5438,9 @@ func TestGeneratedCommandCrossOriginOperationServerPreservesHeaderCase(t *testin
 			BaseURL:                 control.URL,
 			AllowedOperationOrigins: []string{operationServer.URL},
 			PreserveHeaderCase:      true,
+			Profiles: map[string]*config.ProfileConfig{
+				"default": {Headers: []string{"X-Profile: active"}},
+			},
 		},
 	}})
 	if err := os.WriteFile(cfgFile, cfgData, 0o600); err != nil {
@@ -5470,6 +5473,9 @@ func TestGeneratedCommandCrossOriginOperationServerPreservesHeaderCase(t *testin
 	}
 	if got := gotHeader["X-Sourcesystem"]; len(got) != 0 {
 		t.Fatalf("operation server header param was canonicalized: %#v", gotHeader)
+	}
+	if gotHeader.Get("X-Profile") != "active" {
+		t.Fatalf("profile headers missing from operation server request: %#v", gotHeader)
 	}
 }
 

--- a/internal/cli/http.go
+++ b/internal/cli/http.go
@@ -2134,8 +2134,11 @@ func (c *CLI) warnRetryUnsafe(method string, opts request.Options) {
 // httpOptsFromFlags reads the global HTTP flags from cmd and builds an Options.
 func (c *CLI) httpOptsFromFlags(cmd *cobra.Command) (request.Options, error) {
 	gf := globalFlagsFromContext(requestContext(cmd))
+	return c.httpOptsFromGlobalFlags(gf, false)
+}
 
-	if gf.Insecure {
+func (c *CLI) httpOptsFromGlobalFlags(gf GlobalFlags, quiet bool) (request.Options, error) {
+	if gf.Insecure && !quiet {
 		c.warnf("TLS certificate verification is disabled (--rsh-insecure); connections are not secure")
 	}
 
@@ -2182,7 +2185,7 @@ func (c *CLI) httpOptsFromFlags(cmd *cobra.Command) (request.Options, error) {
 		return request.Options{}, err
 	}
 	var logger io.Writer = diagnosticPrefixWriter(c.Stderr)
-	if gf.Silent {
+	if gf.Silent || quiet {
 		logger = nil
 	}
 

--- a/internal/cli/operation_auth.go
+++ b/internal/cli/operation_auth.go
@@ -334,6 +334,9 @@ func (c *CLI) operationAuthCallbacks(apiName, profileName string, selected []sel
 					return err
 				}
 			}
+			if opts.NonInteractive {
+				return nil
+			}
 			return c.runOperationAuthHookPlugins(req, steps)
 		},
 	}
@@ -344,6 +347,9 @@ func (c *CLI) operationAuthCallbacks(apiName, profileName string, selected []sel
 					if err := c.applyOperationAuthStep(req, step, step.forceCapable); err != nil {
 						return err
 					}
+				}
+				if opts.NonInteractive {
+					return nil
 				}
 				return c.runOperationAuthHookPlugins(req, steps)
 			}
@@ -369,14 +375,15 @@ func operationAuthHookContext(steps []operationAuthStep) (map[string]string, map
 }
 
 type operationAuthStep struct {
-	handler      auth.Handler
-	rawParams    map[string]string
-	cacheKey     string
-	forceCapable bool
-	secretKeys   map[string]bool
-	apiName      string
-	profileName  string
-	authType     string
+	handler        auth.Handler
+	rawParams      map[string]string
+	cacheKey       string
+	forceCapable   bool
+	secretKeys     map[string]bool
+	apiName        string
+	profileName    string
+	authType       string
+	nonInteractive bool
 }
 
 func (c *CLI) operationAuthStep(apiName, profileName string, selected selectedOperationAuth, opts authHandlerOptions) (operationAuthStep, error) {
@@ -392,20 +399,27 @@ func (c *CLI) operationAuthStep(apiName, profileName string, selected selectedOp
 	}
 	_, forceCapable := handler.(auth.ForceCapable)
 	return operationAuthStep{
-		handler:      handler,
-		rawParams:    selected.resolved.Config.Params,
-		cacheKey:     selected.resolved.CacheKey,
-		forceCapable: forceCapable,
-		secretKeys:   secretKeys,
-		apiName:      apiName,
-		profileName:  profileName,
-		authType:     selected.resolved.Config.Type,
+		handler:        handler,
+		rawParams:      selected.resolved.Config.Params,
+		cacheKey:       selected.resolved.CacheKey,
+		forceCapable:   forceCapable,
+		secretKeys:     secretKeys,
+		apiName:        apiName,
+		profileName:    profileName,
+		authType:       selected.resolved.Config.Type,
+		nonInteractive: opts.NonInteractive,
 	}, nil
 }
 
 func (c *CLI) applyOperationAuthStep(req *http.Request, s operationAuthStep, force bool) error {
+	if handled, err := c.applyNonInteractiveOAuth(req, s.authType, s.cacheKey, s.apiName, s.profileName, s.nonInteractive); handled {
+		return err
+	}
 	if c.applyCachedOAuthClientCredentials(req, s.authType, s.cacheKey, s.apiName, s.profileName, force) {
 		return nil
+	}
+	if err := rejectNonInteractiveCommandParams(s.rawParams, s.nonInteractive); err != nil {
+		return err
 	}
 	params, err := c.buildAuthParams(s.rawParams)
 	if err != nil {
@@ -420,7 +434,7 @@ func (c *CLI) applyOperationAuthStep(req *http.Request, s operationAuthStep, for
 		return err
 	}
 	preserveInsertedHeader := c.apiPreservesHeaderCase(s.apiName) && !authHeaderPresent(req.Header, s.authType, params)
-	if err := s.handler.Authenticate(req.Context(), req, c.authContext(req.Context(), s.apiName, s.profileName, params, s.cacheKey, force)); err != nil {
+	if err := s.handler.Authenticate(req.Context(), req, c.authContext(req.Context(), s.apiName, s.profileName, params, s.cacheKey, force, s.nonInteractive)); err != nil {
 		return err
 	}
 	if preserveInsertedHeader {

--- a/internal/cli/request_exec.go
+++ b/internal/cli/request_exec.go
@@ -51,20 +51,25 @@ func (c *CLI) prepareRequest(
 		requestOptionQueryContainsCredentials(opts.Query) ||
 		rawURLQueryContainsCredentials(rawURL)
 
-	rawURL, apiName, opts, err := c.applyAPIProfile(rawURL, profileName, opts, authOpts)
-	if err != nil {
-		return nil, err
-	}
-	if apiName == "" && explicitAPIName != "" {
+	var apiName string
+	var err error
+	if explicitAPIName != "" {
 		if c.cfg == nil || c.cfg.APIs == nil || c.cfg.APIs[explicitAPIName] == nil {
 			return nil, fmt.Errorf("API %q is not configured", explicitAPIName)
 		}
-		apiName = explicitAPIName
-		if c.cfg.APIs[explicitAPIName].PreserveHeaderCase {
-			opts.PreserveHeaderCase = true
+		if shortName, _ := splitAPIShortNameSuffix(rawURL); shortName == explicitAPIName {
+			rawURL, _, opts, err = c.applyAPIProfile(rawURL, profileName, opts, authOpts)
+		} else {
+			_, _, opts, err = c.applyAPIProfile(explicitAPIName, profileName, opts, authOpts)
 		}
-		if opts.CacheNamespace == "" {
-			opts.CacheNamespace = c.apiCacheNamespace(apiName, profileName)
+		if err != nil {
+			return nil, err
+		}
+		apiName = explicitAPIName
+	} else {
+		rawURL, apiName, opts, err = c.applyAPIProfile(rawURL, profileName, opts, authOpts)
+		if err != nil {
+			return nil, err
 		}
 	}
 	if !noAuth && operationAuth == nil && apiName != "" && !explicitCredentialContext {
@@ -103,6 +108,9 @@ func (c *CLI) prepareRequest(
 			return nil, fmt.Errorf("url_overrides: %w", err)
 		}
 		rawURL = rewritten
+	}
+	if authOpts.NonInteractive && (opts.TLSSignerName != "" || opts.TLSSignerPath != "") {
+		return nil, fmt.Errorf("TLS signer plugins are not started during shell completion")
 	}
 	opts, err = c.resolveTLSSigner(opts)
 	if err != nil {
@@ -163,7 +171,7 @@ func (c *CLI) prepareRequest(
 	}
 
 	// Chain request-middleware plugins after auth.
-	if !noAuth {
+	if !noAuth && !authOpts.NonInteractive {
 		origOnReq := opts.OnRequest
 		opts.OnRequest = func(req *http.Request) error {
 			if origOnReq != nil {

--- a/internal/request/do.go
+++ b/internal/request/do.go
@@ -162,6 +162,8 @@ type Options struct {
 	// OnUnauthorized, when non-nil, is used by callers that want to retry once
 	// after a 401 with freshly acquired credentials.
 	OnUnauthorized func(*http.Request) error
+	// CheckRedirect overrides the default credential-stripping redirect policy.
+	CheckRedirect func(req *http.Request, via []*http.Request) error
 	// CacheDir, if non-empty, enables RFC 7234 response caching in that
 	// directory.  NoCache overrides this and skips the cache entirely.
 	CacheDir string
@@ -295,10 +297,11 @@ func Do(ctx context.Context, method, rawURL string, body io.Reader, opts Options
 		transport = BuildTransport(opts)
 		builtTransport = true
 	}
-	client := &http.Client{
-		Transport:     transport,
-		CheckRedirect: credentialStrippingRedirectPolicy,
+	checkRedirect := opts.CheckRedirect
+	if checkRedirect == nil {
+		checkRedirect = credentialStrippingRedirectPolicy
 	}
+	client := &http.Client{Transport: transport, CheckRedirect: checkRedirect}
 
 	resp, err := doWithResponseTimeout(client, req, opts.Timeout, opts.HeaderTimeoutOnly, cancelRequest)
 	if err != nil {

--- a/internal/spec/cache.go
+++ b/internal/spec/cache.go
@@ -62,7 +62,7 @@ type opsBlob struct {
 }
 
 const currentCacheSchema = 2
-const currentOperationCacheSchema = 12
+const currentOperationCacheSchema = 13
 
 // OperationCacheStatus describes the freshness of cached operation metadata.
 type OperationCacheStatus struct {

--- a/internal/spec/cache_test.go
+++ b/internal/spec/cache_test.go
@@ -622,6 +622,34 @@ func TestLoadOperationsFromCachePreservesCredentialMetadata(t *testing.T) {
 	}
 }
 
+func TestLoadOperationsFromCachePreservesParameterCompletion(t *testing.T) {
+	dir := t.TempDir()
+	raw := []byte(`{"openapi":"3.1.0","info":{"title":"Test","version":"1"},"paths":{}}`)
+	completion := &ParamCompletion{
+		OperationID: "listProjects", ValuePath: "body.items.id",
+		DescriptionPath: "body.items.name", Bindings: map[string]string{"query.account": "path.account"},
+	}
+	entry := &cacheEntry{
+		Version: "v2", FetchedAt: time.Now(), ExpiresAt: time.Now().Add(time.Hour),
+		Spec: cachedRaw{ContentType: "application/json", Raw: raw},
+	}
+	opts := OperationOptions{BaseURL: "https://api.example.com"}
+	entry.upsertOperationSet(opts, OperationSet{Operations: []Operation{{
+		ID: "listServers", Parameters: []Param{{Name: "project", In: "query", XCLI: ParamXCLI{Completion: completion}}},
+	}}})
+	if err := writeCache(dir, "testapi", entry); err != nil {
+		t.Fatal(err)
+	}
+	set, ok := LoadOperationSetFromCache(dir, "testapi", "v2", nil, opts)
+	if !ok {
+		t.Fatal("expected operation cache hit")
+	}
+	got := set.Operations[0].Parameters[0].XCLI.Completion
+	if !reflect.DeepEqual(got, completion) {
+		t.Fatalf("completion = %#v, want %#v", got, completion)
+	}
+}
+
 func TestLoadOperationSetFromCacheIncludesInfo(t *testing.T) {
 	dir := t.TempDir()
 	raw := []byte(`{"openapi":"3.1.0","info":{"title":"Test","version":"1.0.0","description":"API **docs**"},"paths":{"/items":{"get":{"operationId":"listItems","responses":{"200":{"description":"OK"}}}}}}`)

--- a/internal/spec/completion_test.go
+++ b/internal/spec/completion_test.go
@@ -1,0 +1,133 @@
+package spec
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOperationSetExtractsParameterCompletion(t *testing.T) {
+	loaded, err := (OpenAPILoader{}).Load([]byte(`openapi: 3.1.0
+info: {title: Completion, version: "1"}
+paths:
+  /projects:
+    get:
+      operationId: listProjects
+      parameters:
+        - {name: account, in: query, required: true, schema: {type: string}}
+      responses: {"200": {description: OK}}
+  /accounts/{account}/servers:
+    get:
+      operationId: listServers
+      parameters:
+        - {name: account, in: path, required: true, schema: {type: string}}
+        - name: project
+          in: query
+          schema: {type: string}
+          x-cli-completion:
+            operation_id: listProjects
+            bindings: {query.account: path.account}
+            value_path: body.items.id
+            description_path: body.items.name
+      responses: {"200": {description: OK}}
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	set, err := loaded.OperationSet(OperationOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	completion := set.Operations[1].Parameters[1].XCLI.Completion
+	if completion == nil || completion.OperationID != "listProjects" || completion.Bindings["query.account"] != "path.account" {
+		t.Fatalf("completion = %#v", completion)
+	}
+	if completion.ValuePath != "body.items.id" || completion.DescriptionPath != "body.items.name" {
+		t.Fatalf("completion = %#v", completion)
+	}
+}
+
+func TestOperationSetRejectsUnsafeParameterCompletion(t *testing.T) {
+	loaded, err := (OpenAPILoader{}).Load([]byte(`openapi: 3.1.0
+info: {title: Completion, version: "1"}
+paths:
+  /projects:
+    post:
+      operationId: listProjects
+      responses: {"200": {description: OK}}
+  /servers:
+    get:
+      operationId: listServers
+      parameters:
+        - name: project
+          in: query
+          schema: {type: string}
+          x-cli-completion: {operation_id: listProjects, value_path: body.items.id}
+      responses: {"200": {description: OK}}
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	set, err := loaded.OperationSet(OperationOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if set.Operations[1].Parameters[0].XCLI.Completion != nil {
+		t.Fatal("unsafe provider was accepted")
+	}
+	if len(set.Warnings) != 1 || !strings.Contains(set.Warnings[0], "must use GET or HEAD") {
+		t.Fatalf("warnings = %#v", set.Warnings)
+	}
+}
+
+func TestOperationSetRejectsUnboundProviderParameter(t *testing.T) {
+	loaded, err := (OpenAPILoader{}).Load([]byte(`openapi: 3.1.0
+info: {title: Completion, version: "1"}
+paths:
+  /projects:
+    get:
+      operationId: listProjects
+      parameters:
+        - {name: account, in: query, required: true, schema: {type: string}}
+      responses: {"200": {description: OK}}
+  /servers:
+    get:
+      operationId: listServers
+      parameters:
+        - name: project
+          in: query
+          schema: {type: string}
+          x-cli-completion: {operation_id: listProjects, value_path: body.items.id}
+      responses: {"200": {description: OK}}
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	set, err := loaded.OperationSet(OperationOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if set.Operations[1].Parameters[0].XCLI.Completion != nil {
+		t.Fatal("unbound provider was accepted")
+	}
+	if len(set.Warnings) != 1 || !strings.Contains(set.Warnings[0], "has no binding") {
+		t.Fatalf("warnings = %#v", set.Warnings)
+	}
+}
+
+func TestParameterCompletionRejectsHEADBodySelector(t *testing.T) {
+	err := validateParamCompletion(Operation{}, Operation{Method: "HEAD"}, ParamCompletion{ValuePath: "body.items.id"})
+	if err == nil || !strings.Contains(err.Error(), "cannot read body") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestParameterCompletionRejectsHostBinding(t *testing.T) {
+	current := Operation{Parameters: []Param{{Name: "host", In: "query"}}}
+	provider := Operation{Method: "GET", Parameters: []Param{{Name: "Host", In: "header", Required: true}}}
+	err := validateParamCompletion(current, provider, ParamCompletion{
+		ValuePath: "body.id", Bindings: map[string]string{"header.Host": "query.host"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "HTTP authority") {
+		t.Fatalf("error = %v", err)
+	}
+}

--- a/internal/spec/openapi_helpers.go
+++ b/internal/spec/openapi_helpers.go
@@ -1,7 +1,9 @@
 package spec
 
 import (
+	"fmt"
 	"reflect"
+	"strings"
 
 	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
 )
@@ -89,6 +91,85 @@ func ParamExtBool(p *v3.Parameter, key string) bool {
 	return extValue[bool](p.Extensions.GetOrZero(key))
 }
 
+// ParamCompletionExt decodes and validates the shape of x-cli-completion.
+func ParamCompletionExt(p *v3.Parameter) (*ParamCompletion, error) {
+	if p == nil || p.Extensions == nil {
+		return nil, nil
+	}
+	node := p.Extensions.GetOrZero("x-cli-completion")
+	if nilDecodableNode(node) {
+		return nil, nil
+	}
+	var fields map[string]any
+	if err := node.Decode(&fields); err != nil || fields == nil {
+		return nil, fmt.Errorf("must be an object")
+	}
+	allowed := map[string]bool{"operation_id": true, "value_path": true, "description_path": true, "bindings": true}
+	for key := range fields {
+		if !allowed[key] {
+			return nil, fmt.Errorf("unknown field %q", key)
+		}
+	}
+	var completion ParamCompletion
+	if err := node.Decode(&completion); err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+	completion.OperationID = strings.TrimSpace(completion.OperationID)
+	completion.ValuePath = strings.TrimSpace(completion.ValuePath)
+	completion.DescriptionPath = strings.TrimSpace(completion.DescriptionPath)
+	bindings := make(map[string]string, len(completion.Bindings))
+	if len(completion.Bindings) > 32 {
+		return nil, fmt.Errorf("bindings must contain at most 32 entries")
+	}
+	for target, source := range completion.Bindings {
+		target = strings.TrimSpace(target)
+		source = strings.TrimSpace(source)
+		if target == "" || source == "" || len(target) > 256 || len(source) > 256 {
+			return nil, fmt.Errorf("binding references must be 1 to 256 bytes")
+		}
+		if _, exists := bindings[target]; exists {
+			return nil, fmt.Errorf("duplicate binding target %q", target)
+		}
+		bindings[target] = source
+	}
+	completion.Bindings = bindings
+	if completion.OperationID == "" || len(completion.OperationID) > 256 {
+		return nil, fmt.Errorf("operation_id must be 1 to 256 bytes")
+	}
+	if !validCompletionPath(completion.ValuePath) {
+		return nil, fmt.Errorf("value_path must be a dot-separated path starting with body, headers, headers_all, status, or proto")
+	}
+	if completion.DescriptionPath != "" && !validCompletionPath(completion.DescriptionPath) {
+		return nil, fmt.Errorf("description_path must be a dot-separated path starting with body, headers, headers_all, status, or proto")
+	}
+	return &completion, nil
+}
+
+func validCompletionPath(value string) bool {
+	if len(value) > 512 || strings.ContainsAny(value, "[]|()") {
+		return false
+	}
+	parts := strings.Split(value, ".")
+	if len(parts) > 32 {
+		return false
+	}
+	rootOK := map[string]bool{"body": true, "headers": true, "headers_all": true, "status": true, "proto": true}
+	if !rootOK[parts[0]] {
+		return false
+	}
+	for _, part := range parts {
+		if part == "" || strings.TrimSpace(part) != part {
+			return false
+		}
+	}
+	return true
+}
+
+// ParamHasExtension reports whether a parameter declares an extension.
+func ParamHasExtension(p *v3.Parameter, key string) bool {
+	return p != nil && p.Extensions != nil && !nilDecodableNode(p.Extensions.GetOrZero(key))
+}
+
 type decodableNode interface {
 	Decode(any) error
 }
@@ -105,4 +186,12 @@ func extValue[T any](node decodableNode) T {
 	var value T
 	_ = node.Decode(&value)
 	return value
+}
+
+func nilDecodableNode(node decodableNode) bool {
+	if node == nil {
+		return true
+	}
+	valueOf := reflect.ValueOf(node)
+	return valueOf.Kind() == reflect.Pointer && valueOf.IsNil()
 }

--- a/internal/spec/operation.go
+++ b/internal/spec/operation.go
@@ -30,6 +30,18 @@ type ParamXCLI struct {
 	Name string
 	// Description overrides the OpenAPI parameter description.
 	Description string
+	// Completion describes an opt-in API-backed shell completion provider.
+	Completion *ParamCompletion
+
+	completionError string
+}
+
+// ParamCompletion describes a read-only operation used to complete a parameter.
+type ParamCompletion struct {
+	OperationID     string            `json:"operation_id" cbor:"operation_id" yaml:"operation_id"`
+	ValuePath       string            `json:"value_path" cbor:"value_path" yaml:"value_path"`
+	DescriptionPath string            `json:"description_path,omitempty" cbor:"description_path,omitempty" yaml:"description_path,omitempty"`
+	Bindings        map[string]string `json:"bindings,omitempty" cbor:"bindings,omitempty" yaml:"bindings,omitempty"`
 }
 
 // Param is a single request parameter (path, query, header, or cookie).
@@ -289,6 +301,7 @@ func (s *APISpec) buildOperations(opts OperationOptions) ([]Operation, []string,
 			ops = append(ops, op)
 		}
 	}
+	warnings = append(warnings, validateParamCompletions(ops)...)
 	return ops, warnings, nil
 }
 
@@ -354,6 +367,17 @@ func extractOperation(method, path string, pathParams []*v3.Parameter, op *v3.Op
 		} else if schema := preferredParameterContentSchema(p); schema != nil {
 			schemaHelp, paramType, itemType, defaultValue, defaultValues, hasDefault, enum, objectProperties, jsonSchema, jsonSchemaDialect = parameterSchemaDetails(schema, schemaDialect)
 		}
+		completion, completionErr := ParamCompletionExt(p)
+		xcli := ParamXCLI{
+			Ignore:      ParamExtBool(p, "x-cli-ignore"),
+			Hidden:      ParamExtBool(p, "x-cli-hidden"),
+			Name:        ParamExtString(p, "x-cli-name"),
+			Description: ParamExtString(p, "x-cli-description"),
+			Completion:  completion,
+		}
+		if completionErr != nil {
+			xcli.completionError = completionErr.Error()
+		}
 		o.Parameters = append(o.Parameters, Param{
 			Name:              p.Name,
 			In:                p.In,
@@ -373,15 +397,125 @@ func extractOperation(method, path string, pathParams []*v3.Parameter, op *v3.Op
 			ContentMediaType:  preferredParameterContentMediaType(p),
 			Enum:              enum,
 			ObjectProperties:  objectProperties,
-			XCLI: ParamXCLI{
-				Ignore:      ParamExtBool(p, "x-cli-ignore"),
-				Hidden:      ParamExtBool(p, "x-cli-hidden"),
-				Name:        ParamExtString(p, "x-cli-name"),
-				Description: ParamExtString(p, "x-cli-description"),
-			},
+			XCLI:              xcli,
 		})
 	}
 	return o
+}
+
+func validateParamCompletions(ops []Operation) []string {
+	byID := map[string][]*Operation{}
+	for i := range ops {
+		if ops[i].ID != "" {
+			byID[ops[i].ID] = append(byID[ops[i].ID], &ops[i])
+		}
+	}
+	var warnings []string
+	for i := range ops {
+		for j := range ops[i].Parameters {
+			param := &ops[i].Parameters[j]
+			if param.XCLI.completionError != "" {
+				warnings = append(warnings, completionWarning(ops[i], *param, param.XCLI.completionError))
+				param.XCLI.Completion = nil
+				continue
+			}
+			completion := param.XCLI.Completion
+			if completion == nil {
+				continue
+			}
+			providers := byID[completion.OperationID]
+			if len(providers) != 1 {
+				reason := "provider operation_id is not unique"
+				if len(providers) == 0 {
+					reason = "provider operation_id was not found"
+				}
+				warnings = append(warnings, completionWarning(ops[i], *param, reason))
+				param.XCLI.Completion = nil
+				continue
+			}
+			if err := validateParamCompletion(ops[i], *providers[0], *completion); err != nil {
+				warnings = append(warnings, completionWarning(ops[i], *param, err.Error()))
+				param.XCLI.Completion = nil
+			}
+		}
+	}
+	return warnings
+}
+
+func validateParamCompletion(current, provider Operation, completion ParamCompletion) error {
+	if provider.Method != "GET" && provider.Method != "HEAD" {
+		return fmt.Errorf("provider operation must use GET or HEAD")
+	}
+	if provider.HasBody {
+		return fmt.Errorf("provider operation must not have a request body")
+	}
+	if provider.Method == "HEAD" && (completionPathRoot(completion.ValuePath) == "body" || completionPathRoot(completion.DescriptionPath) == "body") {
+		return fmt.Errorf("HEAD provider selectors cannot read body")
+	}
+	bound := map[string]bool{}
+	targets := make([]string, 0, len(completion.Bindings))
+	for target := range completion.Bindings {
+		targets = append(targets, target)
+	}
+	sort.Strings(targets)
+	for _, target := range targets {
+		source := completion.Bindings[target]
+		targetIn, targetName, err := parseCompletionParamRef(target)
+		if err != nil {
+			return fmt.Errorf("binding target %q: %w", target, err)
+		}
+		if targetIn == "header" && strings.EqualFold(targetName, "Host") {
+			return fmt.Errorf("binding target %q cannot override HTTP authority", target)
+		}
+		sourceIn, sourceName, err := parseCompletionParamRef(source)
+		if err != nil {
+			return fmt.Errorf("binding source %q: %w", source, err)
+		}
+		if !completionParamExists(provider, targetIn, targetName) {
+			return fmt.Errorf("binding target %q is not an exposed provider parameter", target)
+		}
+		if !completionParamExists(current, sourceIn, sourceName) {
+			return fmt.Errorf("binding source %q is not an exposed current parameter", source)
+		}
+		bound[target] = true
+	}
+	for _, parameter := range provider.Parameters {
+		if parameter.Required && !parameter.XCLI.Ignore && !bound[parameter.In+"."+parameter.Name] {
+			return fmt.Errorf("required provider parameter %q has no binding", parameter.In+"."+parameter.Name)
+		}
+	}
+	return nil
+}
+
+func completionPathRoot(path string) string {
+	root, _, _ := strings.Cut(path, ".")
+	return root
+}
+
+func parseCompletionParamRef(value string) (string, string, error) {
+	location, name, ok := strings.Cut(value, ".")
+	if !ok || name == "" {
+		return "", "", fmt.Errorf("expected <location>.<name>")
+	}
+	switch location {
+	case "path", "query", "header", "cookie":
+		return location, name, nil
+	default:
+		return "", "", fmt.Errorf("unsupported location %q", location)
+	}
+}
+
+func completionParamExists(operation Operation, location, name string) bool {
+	for _, parameter := range operation.Parameters {
+		if parameter.In == location && parameter.Name == name && !parameter.XCLI.Ignore {
+			return true
+		}
+	}
+	return false
+}
+
+func completionWarning(operation Operation, parameter Param, reason string) string {
+	return fmt.Sprintf("operation %q parameter %s.%s ignores x-cli-completion: %s", operation.ID, parameter.In, parameter.Name, reason)
 }
 
 func securitySchemes(components *v3.Components) map[string]*v3.SecurityScheme {

--- a/internal/spec/xcli_extensions.go
+++ b/internal/spec/xcli_extensions.go
@@ -133,6 +133,9 @@ func (b *xcliExtensionReportBuilder) addOperationDetails(method, rawPath string,
 		if value := ParamExtString(param, "x-cli-name"); value != "" {
 			b.add("parameter_renamed", "x-cli-name", paramLocation, paramName, value, "renames the generated argument or flag")
 		}
+		if ParamHasExtension(param, "x-cli-completion") {
+			b.add("parameter_completion", "x-cli-completion", paramLocation, paramName, "", "may call a declared GET or HEAD operation during shell completion")
+		}
 	}
 }
 
@@ -171,6 +174,7 @@ var xcliExtensionSummaryOrder = []xcliExtensionSummaryItem{
 	{kind: "parameter_ignored", singular: "ignored parameter", plural: "ignored parameters"},
 	{kind: "parameter_hidden", singular: "hidden parameter", plural: "hidden parameters"},
 	{kind: "parameter_renamed", singular: "renamed parameter", plural: "renamed parameters"},
+	{kind: "parameter_completion", singular: "API-backed parameter completion", plural: "API-backed parameter completions"},
 }
 
 func pluralize(count int, singular, plural string) string {

--- a/internal/spec/xcli_extensions_test.go
+++ b/internal/spec/xcli_extensions_test.go
@@ -54,6 +54,9 @@ paths:
           schema:
             type: string
           x-cli-hidden: true
+          x-cli-completion:
+            operation_id: listAdmin
+            value_path: body.items.id
         - name: internal
           in: query
           schema:
@@ -82,6 +85,7 @@ paths:
 		"1 ignored parameter",
 		"1 hidden parameter",
 		"1 renamed parameter",
+		"1 API-backed parameter completion",
 	} {
 		if !strings.Contains(gotSummary, want) {
 			t.Fatalf("summary %q missing %q", gotSummary, want)
@@ -91,15 +95,16 @@ paths:
 		t.Fatalf("x-cli-description should not be summarized: %q", gotSummary)
 	}
 	wantKinds := map[string]bool{
-		"config":            false,
-		"path_hidden":       false,
-		"operation_ignored": false,
-		"operation_hidden":  false,
-		"operation_renamed": false,
-		"operation_aliases": false,
-		"parameter_ignored": false,
-		"parameter_hidden":  false,
-		"parameter_renamed": false,
+		"config":               false,
+		"path_hidden":          false,
+		"operation_ignored":    false,
+		"operation_hidden":     false,
+		"operation_renamed":    false,
+		"operation_aliases":    false,
+		"parameter_ignored":    false,
+		"parameter_hidden":     false,
+		"parameter_renamed":    false,
+		"parameter_completion": false,
 	}
 	for _, detail := range report.Details {
 		if _, ok := wantKinds[detail.Kind]; ok {

--- a/site/content/en/docs/reference/openapi-cli-integration.md
+++ b/site/content/en/docs/reference/openapi-cli-integration.md
@@ -91,6 +91,69 @@ the original OpenAPI parameter name is preserved on the wire.
 removes that parameter from the generated CLI; `x-cli-hidden` keeps it callable
 but omits it from ordinary help.
 
+## API-Backed Parameter Completion
+
+Static OpenAPI `enum` values are completed locally. For values managed by the
+API, a parameter can opt into a read-only completion provider:
+
+```yaml
+paths:
+  /projects:
+    get:
+      operationId: listProjects
+      parameters:
+        - name: account
+          in: query
+          required: true
+          schema: {type: string}
+      responses:
+        "200": {description: OK}
+
+  /accounts/{account}/servers:
+    get:
+      operationId: listServers
+      parameters:
+        - name: account
+          in: path
+          required: true
+          schema: {type: string}
+        - name: project
+          in: query
+          schema: {type: string}
+          x-cli-completion:
+            operation_id: listProjects
+            bindings:
+              query.account: path.account
+            value_path: body.items.id
+            description_path: body.items.name
+      responses:
+        "200": {description: OK}
+```
+
+`operation_id` names an existing operation in the same synced operation set. It
+must be a
+`GET` or `HEAD` operation without a request body. Bindings map a provider
+parameter to an already supplied parameter on the current command. Parameter
+references use `<location>.<original-name>`, where location is `path`, `query`,
+`header`, or `cookie`.
+
+`value_path` and optional `description_path` are bounded, dot-separated field
+paths against the normalized response roots `body`, `headers`, `headers_all`,
+`status`, and `proto`. Field projection across response arrays is automatic.
+Values must resolve to a scalar or list of scalars. Descriptions, when present,
+must resolve to the same number of items.
+
+Pressing `Tab` may make one authenticated provider request. Restish applies the
+active profile, TLS settings, URL overrides, operation-origin policy, parameter
+serialization, and built-in non-interactive authentication. It does not retry,
+paginate, prompt, start local auth or TLS plugins, or run command-based secret
+sources. Only built-in response codecs run. The request has a two-second
+deadline and a 1 MiB response limit.
+Candidates are sanitized and capped at 100. Unauthenticated candidate sets are
+cached for 30 seconds in the private response-cache directory; authenticated
+sets are not persisted. `--rsh-no-cache` bypasses this cache. Any failure returns
+no candidates. A static `enum` always takes precedence and stays offline.
+
 ## Hide Or Ignore Operations
 
 ```yaml


### PR DESCRIPTION
## Summary

- add parameter-level `x-cli-completion` metadata that references a declared `GET` or `HEAD` operation, parameter bindings, and bounded value/description paths
- persist the typed provider metadata during `api sync` and use it for required positional arguments and optional flags, while keeping static enums offline and authoritative
- execute provider requests through Restish profile, TLS, auth, serialization, URL override, and origin handling with no redirects, retries, pagination, prompts, or local plugin execution
- bound and sanitize responses and candidates, cache only unauthenticated results, and report the extension through sync and doctor metadata

Closes #421

## Behavior

A local server at `http://127.0.0.1:18081` served the checked-in completion fixture and this provider response:

```json
{"items":[{"id":"acct-1","name":"Primary Account"}]}
```

The API config pointed `base_url` and `spec_url` at that server. I synced the same spec separately with the v2.3.0 binary and the branch binary, then ran the same Cobra completion command.

Before:

```console
$ restish-v2.3.0 --rsh-config restish.json api sync demo
$ restish-v2.3.0 --rsh-config restish.json __complete demo list-servers ac
Completion ended with directive: ShellCompDirectiveNoFileComp
:4
```

After:

```console
$ restish --rsh-config restish.json api sync demo
$ restish --rsh-config restish.json __complete demo list-servers ac
Completion ended with directive: ShellCompDirectiveNoFileComp
acct-1	Primary Account
:4
```

The checked-in test starts the same local fake API and a fresh CLI using only the synced cache:

```console
$ go test ./internal/cli -run "^TestDynamicParameterCompletionAfterAPISync$" -count=1
ok  	github.com/rest-sh/restish/v2/internal/cli	0.035s
```

---

> [!NOTE]
> AI assistance: PR description, documentation, test scaffolding.
