### PR TITLE
feat(embed): preserve command plugins in promoted CLIs

### DIFF
--- a/docs/design/042-custom-cli-embedding-surface.md
+++ b/docs/design/042-custom-cli-embedding-surface.md
@@ -45,6 +45,7 @@ useful for scripting, CI, support tickets, and user recovery.
   first run by loading the configured spec source before commands are needed.
 - Keep a small support surface that uses app vocabulary rather than leaking the
   Restish implementation name.
+- Preserve commands contributed by plugins installed in the active config.
 - Preserve scriptability for auth headers, cache cleanup, config inspection,
   diagnostics, completion, and version output.
 - Keep the public API small enough to maintain permanently.
@@ -58,8 +59,6 @@ useful for scripting, CI, support tickets, and user recovery.
 - Do not add a public embedded OpenAPI bytes helper in the first pass.
 - Do not add an immutable "never update OpenAPI from the network" embedded-spec
   mode in the first pass.
-- Do not add arbitrary per-command-family visibility subsets until a real
-  embedder needs them.
 - Do not bundle out-of-process plugin executables into custom binaries.
 
 ## Current Constraints
@@ -148,7 +147,10 @@ The design intent is:
   root command.
 - The promoted API is the primary API. There is no separate primary/default API
   concept in the first pass.
-- Support commands stay at root by default when an API is promoted.
+- Support commands, including plugin management, stay at root by default when
+  an API is promoted.
+- Commands contributed by command plugins installed in the active config stay
+  at root. Other stock command families remain hidden.
 - `SupportCommandNamespace` moves support commands under that command name, for
   example `acme cli cache clear`.
 - `HideSupportCommands` removes support commands from the custom CLI surface.
@@ -172,7 +174,9 @@ acme cache
 acme config
 acme doctor
 acme completion
+acme plugin
 acme version
+acme <command-plugin-command> [...]
 ```
 
 The default single-API surface hides stock Restish control-plane commands that
@@ -180,7 +184,6 @@ would distract from a branded API CLI:
 
 ```text
 api
-plugin
 get|head|options|post|put|patch|delete
 shell
 links
@@ -318,6 +321,10 @@ on demand, refresh-failed with stale fallback, or unavailable.
 Generated operations, app support commands, and the optional support namespace
 must not silently shadow one another.
 
+Command-plugin commands must not collide with promoted operations, app support
+commands, or the support namespace. Such collisions fail startup with an
+actionable configuration error.
+
 If a promoted operation collides with a root support command such as `auth`,
 `cache`, or `doctor`, startup should fail with an actionable error that suggests
 moving support commands under a namespace or hiding them.
@@ -345,6 +352,9 @@ instead of maintaining a second root builder for custom CLIs:
 - Skip adding the promoted API's normal wrapper/short-name command at root.
 - Move, hide, or retain builtin support commands according to
   `SupportCommandNamespace` and `HideSupportCommands`.
+- Capture installed command-plugin commands from the stock root before
+  transforming it, then re-add those existing command nodes without changing
+  their help, flags, completion, grouping, or execution behavior.
 - Add only the minimal app-shaped auth sugar described above.
 - Reuse cache, config, and doctor behavior where possible, adjusting help text
   and primary-API defaults rather than duplicating implementation.

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -382,6 +382,20 @@ func TestCommandSurfaceSupportCommandsUnderNamespace(t *testing.T) {
 	if got := out.String(); !strings.Contains(got, "clear") {
 		t.Fatalf("namespaced cache help missing subcommand:\n%s", got)
 	}
+
+	c, out, _ = newTestCLI(t)
+	writeCommandSurfaceSpecConfig(t, c, "api", "getPing")
+	c.SetCommandName("example")
+	c.SetCommandSurface(cli.CommandSurface{
+		PromotedAPI:             "api",
+		SupportCommandNamespace: "cli",
+	})
+	if err := c.Run([]string{"example", "cli", "plugin", "--help"}); err != nil {
+		t.Fatalf("namespaced plugin help: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "Manage example plugins") {
+		t.Fatalf("namespaced plugin help missing branded description:\n%s", got)
+	}
 }
 
 func TestCommandSurfaceHideSupportCommands(t *testing.T) {

--- a/internal/cli/command_plugin_test.go
+++ b/internal/cli/command_plugin_test.go
@@ -13,6 +13,9 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/rest-sh/restish/v2/config"
+	"github.com/rest-sh/restish/v2/internal/cli"
 )
 
 type captureWriter struct {
@@ -80,6 +83,83 @@ func TestCommandPluginGreet(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "Hello from plugin") {
 		t.Errorf("expected greeting in stdout, got:\n%s", out.String())
+	}
+}
+
+func TestCommandSurfacePreservesCommandPlugins(t *testing.T) {
+	installCmdPlugin(t)
+
+	c, out, _ := newTestCLI(t)
+	var errOut captureWriter
+	c.Stderr = &errOut
+	c.Hooks().ConfigPath = sharedPluginConfigPath(t)
+	writeCommandSurfaceSpecConfig(t, c, "api", "getPing")
+	c.SetCommandSurface(cli.CommandSurface{
+		PromotedAPI: "api",
+	})
+
+	if err := c.Run([]string{"example", "greet"}); err != nil {
+		t.Fatalf("promoted command plugin: %v", err)
+	}
+	if !strings.Contains(errOut.String(), "Greeting in progress") {
+		t.Errorf("expected progress on stderr, got:\n%s", errOut.String())
+	}
+	if !strings.Contains(out.String(), "Hello from plugin") {
+		t.Errorf("expected greeting in stdout, got:\n%s", out.String())
+	}
+}
+
+func TestCommandSurfaceListsAllCommandPlugins(t *testing.T) {
+	installCmdPlugin(t)
+
+	c, out, _ := newTestCLI(t)
+	c.Hooks().ConfigPath = sharedPluginConfigPath(t)
+	writeCommandSurfaceSpecConfig(t, c, "api", "getPing")
+	c.SetCommandSurface(cli.CommandSurface{
+		PromotedAPI: "api",
+	})
+
+	if err := c.Run([]string{"example", "--help"}); err != nil {
+		t.Fatalf("promoted help: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "greet") {
+		t.Fatalf("selected command plugin missing from help:\n%s", got)
+	}
+	if !strings.Contains(got, "pipe") {
+		t.Fatalf("command plugin missing from help:\n%s", got)
+	}
+}
+
+func TestCommandSurfaceCommandPluginDoesNotRequirePromotedMetadata(t *testing.T) {
+	installCmdPlugin(t)
+
+	c, out, _ := newTestCLI(t)
+	c.Hooks().ConfigPath = sharedPluginConfigPath(t)
+	c.SetDefaultConfig(&config.Config{APIs: map[string]*config.APIConfig{
+		"api": {BaseURL: "http://127.0.0.1:1"},
+	}})
+	c.SetCommandSurface(cli.CommandSurface{PromotedAPI: "api"})
+
+	if err := c.Run([]string{"example", "greet", "--help"}); err != nil {
+		t.Fatalf("command plugin help without promoted metadata: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "greet") {
+		t.Fatalf("command plugin help missing command:\n%s", got)
+	}
+}
+
+func TestCommandSurfaceCommandPluginOperationCollisionErrors(t *testing.T) {
+	installCmdPlugin(t)
+
+	c, _, _ := newTestCLI(t)
+	c.Hooks().ConfigPath = sharedPluginConfigPath(t)
+	writeCommandSurfaceSpecConfig(t, c, "api", "greet")
+	c.SetCommandSurface(cli.CommandSurface{PromotedAPI: "api"})
+
+	err := c.Run([]string{"example", "--help"})
+	if err == nil || !strings.Contains(err.Error(), "command plugin") {
+		t.Fatalf("collision error = %v, want command plugin collision", err)
 	}
 }
 

--- a/internal/cli/command_surface_embed.go
+++ b/internal/cli/command_surface_embed.go
@@ -101,12 +101,20 @@ func (c *CLI) promotedAPICommandMetadataNeeded(scan cliArgScan) bool {
 		return true
 	}
 	if scan.FirstCommand == "help" {
-		return scan.SecondCommand == "" || !c.isSupportCommandToken(scan.SecondCommand)
+		return scan.SecondCommand == "" || !c.isSurfaceCommandToken(scan.SecondCommand)
 	}
 	if scan.FirstCommand == "__complete" || scan.FirstCommand == "__completeNoDesc" {
-		return true
+		return scan.SecondCommand == "" || !c.isCommandPluginToken(scan.SecondCommand)
 	}
-	return !c.isSupportCommandToken(scan.FirstCommand)
+	return !c.isSurfaceCommandToken(scan.FirstCommand)
+}
+
+func (c *CLI) isSurfaceCommandToken(token string) bool {
+	return c.isSupportCommandToken(token) || c.isCommandPluginToken(token)
+}
+
+func (c *CLI) isCommandPluginToken(token string) bool {
+	return token != "" && c.pluginCommandNames[token] != ""
 }
 
 func (c *CLI) isSupportCommandToken(token string) bool {
@@ -126,6 +134,7 @@ func promotedSupportCommandNames() map[string]bool {
 		"completion": true,
 		"config":     true,
 		"doctor":     true,
+		"plugin":     true,
 		"version":    true,
 	}
 }
@@ -140,6 +149,7 @@ func (c *CLI) applyCommandSurface(root, promotedAPICmd *cobra.Command, scan cliA
 	}
 
 	support := c.promotedSupportCommands(root, apiName)
+	commandPlugins := c.promotedCommandPluginCommands(root)
 	for _, cmd := range root.Commands() {
 		root.RemoveCommand(cmd)
 	}
@@ -158,13 +168,29 @@ func (c *CLI) applyCommandSurface(root, promotedAPICmd *cobra.Command, scan cliA
 	if err := c.checkPromotedCommandCollisions(promoted, support); err != nil {
 		return err
 	}
+	if err := c.checkCommandPluginCollisions(promoted, commandPlugins, support); err != nil {
+		return err
+	}
 
 	c.addSupportCommandsForSurface(root, support)
 	for _, cmd := range promoted {
 		root.AddCommand(cmd)
 	}
+	for _, cmd := range commandPlugins {
+		root.AddCommand(cmd)
+	}
 	c.installPromotedRootFallback(root, cfg, originalArgs)
 	return nil
+}
+
+func (c *CLI) promotedCommandPluginCommands(root *cobra.Command) []*cobra.Command {
+	var commands []*cobra.Command
+	for _, cmd := range root.Commands() {
+		if c.isCommandPluginToken(cmd.Name()) {
+			commands = append(commands, cmd)
+		}
+	}
+	return commands
 }
 
 func (c *CLI) promotedSupportCommands(root *cobra.Command, apiName string) map[string]*cobra.Command {
@@ -194,6 +220,10 @@ func (c *CLI) brandPromotedSupportCommands(support map[string]*cobra.Command) {
 	if cmd := support["doctor"]; cmd != nil {
 		cmd.Short = fmt.Sprintf("Diagnose %s configuration and runtime paths", name)
 	}
+	if cmd := support["plugin"]; cmd != nil {
+		cmd.Short = fmt.Sprintf("Manage %s plugins", name)
+		cmd.Long = strings.Replace(cmd.Long, "Manage Restish plugins.", fmt.Sprintf("Manage %s plugins.", name), 1)
+	}
 	if cmd := support["version"]; cmd != nil {
 		cmd.Short = fmt.Sprintf("Print the %s version", name)
 	}
@@ -211,6 +241,30 @@ func (c *CLI) checkPromotedCommandCollisions(promoted []*cobra.Command, support 
 		}
 		if ns == "" && !c.commandSurface.HideSupportCommands && support[name] != nil {
 			return fmt.Errorf("command surface: promoted operation %q collides with support command %q; set SupportCommandNamespace or HideSupportCommands", name, name)
+		}
+	}
+	return nil
+}
+
+func (c *CLI) checkCommandPluginCollisions(promoted, plugins []*cobra.Command, support map[string]*cobra.Command) error {
+	promotedNames := map[string]bool{}
+	for _, cmd := range promoted {
+		promotedNames[cmd.Name()] = true
+	}
+	ns := c.commandSurface.SupportCommandNamespace
+	for _, cmd := range plugins {
+		name := cmd.Name()
+		if name == "" {
+			continue
+		}
+		if promotedNames[name] {
+			return fmt.Errorf("command surface: command plugin %q collides with promoted operation %q; rename the plugin command or operation", name, name)
+		}
+		if ns != "" && name == ns {
+			return fmt.Errorf("command surface: command plugin %q collides with support command namespace %q; choose another SupportCommandNamespace", name, ns)
+		}
+		if ns == "" && !c.commandSurface.HideSupportCommands && support[name] != nil {
+			return fmt.Errorf("command surface: command plugin %q collides with support command %q; set SupportCommandNamespace or rename the plugin command", name, name)
 		}
 	}
 	return nil

--- a/site/content/en/docs/reference/embedding.md
+++ b/site/content/en/docs/reference/embedding.md
@@ -190,6 +190,25 @@ Global Restish flags (`--rsh-profile`, `--rsh-output-format`, ...) remain
 available. The promoted API must be configured and its spec loadable when
 generated commands are needed. For a reliable first run, configure `SpecURL`.
 
+### Plugins in promoted CLIs
+
+The `plugin` command is a support command. By default, this command stays at
+the command root. `SupportCommandNamespace` moves this command into the
+specified namespace. `HideSupportCommands` removes this command.
+
+```text
+mycli support plugin install ./restish-example
+```
+
+Restish keeps commands from installed command plugins at the command root.
+Users can run these commands with generated API commands. Generic HTTP commands
+and API-management commands stay hidden.
+
+Restish reports a configuration error when a plugin command has the same name
+as a promoted operation, a support command, or the support namespace. Use a
+separate configuration file for a custom CLI. The separate file isolates its
+plugins from the stock `restish` CLI.
+
 ## Related Pages
 
 - [API Setup and Discovery](/docs/guides/api-setup-and-discovery/)


### PR DESCRIPTION
## Summary

Preserve installed command-plugin commands when an embedded CLI promotes an API to the command root.

Plugin management now joins the existing support command family. Embedders can keep it at root, move it with `SupportCommandNamespace`, or remove it with `HideSupportCommands`.

## Motivation

Promoting an API currently removes command-plugin commands from the generated command tree. Branded CLIs must disable promotion for plugin invocations or implement custom argument dispatch.

This change lets embedded CLIs provide one consistent command surface:

```text
mycli support plugin install ...
mycli list-resources
mycli my-plugin-command
```

## Changes

- Preserve commands contributed by plugins installed in the active config.
- Add `plugin` to the promoted support command family.
- Brand plugin management help for the embedded CLI.
- Skip promoted API metadata loading for direct plugin command help and execution.
- Report collisions with promoted operations, support commands, or the support namespace.
- Update the embedding design and reference documentation.

The plugin protocol and stock Restish command surface are unchanged.

## Validation

- `go test ./...`
- `go test -tags=integration ./...`
- Built Restish and all bundled plugin binaries.
- Passed docgen, Hugo, documentation link, and example checks.

Closes #424