### PR TITLE
fix(auth): read token cache on Windows

### DIFF
--- a/auth/tokencache.go
+++ b/auth/tokencache.go
@@ -184,7 +184,10 @@ func (c *TokenCache) load() (map[string]CachedToken, error) {
 }
 
 func (c *TokenCache) loadLocked() (map[string]CachedToken, error) {
-	if insecure, err := config.ConfigFileHasInsecurePermissions(c.path); err != nil {
+	// On platforms where the check is unsupported (Windows), fall through:
+	// failing closed here would force a fresh browser login on every request
+	// because the token written by the previous login could never be read back.
+	if insecure, err := config.ConfigFileHasInsecurePermissions(c.path); err != nil && !errors.Is(err, config.ErrPermissionCheckUnsupported) {
 		return nil, err
 	} else if insecure {
 		return nil, fmt.Errorf("token cache %s is group/world-readable; run chmod 600 %s", c.path, c.path)

--- a/auth/tokencache_windows_test.go
+++ b/auth/tokencache_windows_test.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// On Windows ConfigFileHasInsecurePermissions returns ErrPermissionCheckUnsupported
+// for every existing file. The cache must still read back what it wrote, or every
+// request after the first login re-opens the browser.
+func TestTokenCache_ReadsExistingFileOnWindows(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tokens.cbor")
+	tc := NewTokenCache(path)
+	if err := tc.Set("api:default", CachedToken{AccessToken: "abc"}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("cache file not written: %v", err)
+	}
+	got, err := NewTokenCache(path).Get("api:default")
+	if err != nil {
+		t.Fatalf("Get on existing file: %v", err)
+	}
+	if got == nil || got.AccessToken != "abc" {
+		t.Fatalf("Get = %#v, want access_token abc", got)
+	}
+}

--- a/internal/cli/external_tool_approval.go
+++ b/internal/cli/external_tool_approval.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -52,7 +53,7 @@ func (c *CLI) externalToolApprovalsPath() string {
 
 func (c *CLI) loadExternalToolApprovals(hash string) (map[string]bool, bool, error) {
 	path := c.externalToolApprovalsPath()
-	if insecure, err := config.ConfigFileHasInsecurePermissions(path); err != nil {
+	if insecure, err := config.ConfigFileHasInsecurePermissions(path); err != nil && !errors.Is(err, config.ErrPermissionCheckUnsupported) {
 		return nil, false, err
 	} else if insecure {
 		return nil, false, fmt.Errorf("external-tool approvals %s is group/world-readable; run chmod 600 %s", path, path)


### PR DESCRIPTION
On Windows, `config.ConfigFileHasInsecurePermissions` returns `ErrPermissionCheckUnsupported` for every *existing* file (`config/config.go:217`). `TokenCache.loadLocked` (`auth/tokencache.go:187`) treated that as a hard error, so:

1. The first OAuth login works — `tokens.cbor` does not exist yet, the check short-circuits, the token is written.
2. Every subsequent request: `Get` errors → treated as "no cached token" → browser flow again. The post-flow `Cache.Set` fails the same way (error discarded at `internal/auth/oauth_authcode.go:165`).

Net effect: on Windows, every authorization-code request opens the browser, forever. Reproduced with an embedded CLI on restish v2.3.0, Windows 11: `login` succeeds, the very next command re-prompts.

This treats the unsupported-check error as "not insecure" in `loadLocked` and in the identical pattern in `internal/cli/external_tool_approval.go`. The checker's contract is unchanged; `doctor` already reports the unsupported case as `unknown`.

Adds a `//go:build windows` test asserting a freshly written cache can be read back.
