### PR TITLE
fix(auth): open the OAuth browser on Windows without cmd.exe

### DIFF
--- a/internal/auth/oauth_authcode.go
+++ b/internal/auth/oauth_authcode.go
@@ -837,10 +837,11 @@ func defaultOpenBrowserCommandForGOOS(goos, rawURL string) *exec.Cmd {
 		case "darwin":
 			cmd = exec.Command("open", "--", rawURL)
 		case "windows":
-			// Pass an explicit empty title ("") before the URL so that special
-			// characters in the URL are not misinterpreted as window title or
-			// cmd /c start flags.
-			cmd = exec.Command("cmd", "/c", "start", "", "--", rawURL)
+			// Do not go through cmd.exe: "start" has no "--" convention (it tries
+			// to launch a program named "--"), and cmd splits an unquoted command
+			// line at "&", which every authorization URL contains. rundll32 hands
+			// the URL to the default browser with no shell in between.
+			cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", rawURL)
 		default:
 			cmd = exec.Command("xdg-open", rawURL)
 		}

--- a/internal/auth/oauth_authcode_test.go
+++ b/internal/auth/oauth_authcode_test.go
@@ -1293,15 +1293,24 @@ func TestDefaultOpenBrowserReturnsAfterStart(t *testing.T) {
 }
 
 func TestDefaultOpenBrowserCommandUsesArgumentSeparator(t *testing.T) {
-	if runtime.GOOS == "linux" {
-		// xdg-open does not support --, so we skip the separator check on Linux.
-		// Real OAuth URLs always start with https://, so this is safe in practice.
-		t.Skip("xdg-open does not accept --")
+	if runtime.GOOS != "darwin" {
+		// Only macOS "open" accepts --; xdg-open and rundll32 do not. Real OAuth
+		// URLs always start with https://, so this is safe in practice.
+		t.Skip("only the darwin opener accepts --")
 	}
 	cmd := defaultOpenBrowserCommand("-https://example.com")
 	args := strings.Join(cmd.Args, "\x00")
 	if !strings.Contains(args, "\x00--\x00-https://example.com") {
 		t.Fatalf("browser command should pass -- before URL, got %#v", cmd.Args)
+	}
+}
+
+func TestDefaultOpenBrowserCommandWindowsUsesRundll32WithoutShell(t *testing.T) {
+	url := "https://example.com/authorize?client_id=abc&state=xyz&code_challenge=q"
+	cmd := defaultOpenBrowserCommandForGOOS("windows", url)
+	want := []string{"rundll32", "url.dll,FileProtocolHandler", url}
+	if !reflect.DeepEqual(cmd.Args, want) {
+		t.Fatalf("windows browser command args = %#v, want %#v", cmd.Args, want)
 	}
 }
 


### PR DESCRIPTION
The Windows browser opener (`internal/auth/oauth_authcode.go`) ran:

```
cmd /c start "" -- <url>
```

`start` has no `--` convention — it treats `--` as the program to launch, so every authorization-code login on Windows fails with a system dialog *"Windows cannot find '--'"* and the flow never reaches the browser. Reproduced with v2.3.0 on Windows 11.

Dropping the separator alone is not enough: `cmd` splits an unquoted command line at `&`, and every authorization URL carries several (`client_id=…&redirect_uri=…&code_challenge=…`). Go's argument quoting targets `CreateProcess`, not `cmd` metacharacters.

This switches the default to `rundll32 url.dll,FileProtocolHandler <url>` — no shell in between, URL passed verbatim (the same mechanism `pkg/browser` uses). Verified on Windows 11 via `BROWSER="rundll32 url.dll,FileProtocolHandler"` before making it the default. `BROWSER` override behaviour is unchanged.

Test: `TestDefaultOpenBrowserCommandWindowsUsesRundll32WithoutShell` (runs on every OS via `defaultOpenBrowserCommandForGOOS`); the existing `--` separator test is now darwin-only, since `open` is the only default opener that accepts it.
