### PR TITLE
fix(auth): fall back to interactive auth when a provider rejects the refresh token

### DIFF
--- a/internal/auth/oauth_authcode.go
+++ b/internal/auth/oauth_authcode.go
@@ -133,7 +133,7 @@ func (h *AuthorizationCode) resolveToken(ctx context.Context, params map[string]
 		if h.Stderr != nil {
 			fmt.Fprintf(h.Stderr, "OAuth refresh failed: %v\n", err)
 		}
-		if !isTokenEndpointErrorCode(err, "invalid_grant") {
+		if !isRefreshTokenRejected(err) {
 			return "", err
 		}
 		clearRejectedOAuthToken(h.Cache, cacheKey, h.Stderr)

--- a/internal/auth/oauth_common.go
+++ b/internal/auth/oauth_common.go
@@ -91,6 +91,9 @@ type tokenEndpointError struct {
 	ErrorCode   string
 	Description string
 	Body        string
+	// ProviderCode is a non-RFC 6749 machine-readable code some providers send
+	// alongside or instead of "error" (Supabase GoTrue: "error_code").
+	ProviderCode string
 }
 
 func (e *tokenEndpointError) Error() string {
@@ -398,19 +401,45 @@ func parseTokenEndpointError(statusCode int, body []byte) error {
 	var decoded struct {
 		Error            string `json:"error"`
 		ErrorDescription string `json:"error_description"`
+		ProviderCode     string `json:"error_code"`
 	}
 	_ = json.Unmarshal(body, &decoded)
 	return &tokenEndpointError{
-		StatusCode:  statusCode,
-		ErrorCode:   decoded.Error,
-		Description: decoded.ErrorDescription,
-		Body:        redactTokenEndpointBody(body),
+		StatusCode:   statusCode,
+		ErrorCode:    decoded.Error,
+		Description:  decoded.ErrorDescription,
+		Body:         redactTokenEndpointBody(body),
+		ProviderCode: decoded.ProviderCode,
 	}
 }
 
 func isTokenEndpointErrorCode(err error, code string) bool {
 	var tokenErr *tokenEndpointError
 	return errors.As(err, &tokenErr) && tokenErr.ErrorCode == code
+}
+
+// rejectedRefreshProviderCodes are provider-specific codes that mean the
+// refresh token itself is dead (revoked, rotated away, or its session gone), the
+// same situation RFC 6749 expresses as invalid_grant. Supabase GoTrue answers a
+// refresh with 400 {"error_code":"refresh_token_not_found"} rather than
+// {"error":"invalid_grant"}.
+var rejectedRefreshProviderCodes = map[string]bool{
+	"refresh_token_not_found":    true,
+	"refresh_token_already_used": true,
+	"session_not_found":          true,
+	"session_expired":            true,
+}
+
+// isRefreshTokenRejected reports whether a refresh failure means the cached
+// refresh token can never succeed again, so the caller should clear it and fall
+// back to interactive auth instead of failing every request until a manual
+// logout. Network errors and 5xx responses are not rejections.
+func isRefreshTokenRejected(err error) bool {
+	if isTokenEndpointErrorCode(err, "invalid_grant") {
+		return true
+	}
+	var tokenErr *tokenEndpointError
+	return errors.As(err, &tokenErr) && rejectedRefreshProviderCodes[tokenErr.ProviderCode]
 }
 
 func redactTokenEndpointBody(body []byte) string {

--- a/internal/auth/oauth_device_code.go
+++ b/internal/auth/oauth_device_code.go
@@ -77,7 +77,7 @@ func (h *DeviceCode) resolveToken(ctx context.Context, params map[string]string,
 		if h.Stderr != nil {
 			fmt.Fprintf(h.Stderr, "OAuth refresh failed: %v\n", err)
 		}
-		if !isTokenEndpointErrorCode(err, "invalid_grant") {
+		if !isRefreshTokenRejected(err) {
 			return "", err
 		}
 		clearRejectedOAuthToken(h.Cache, cacheKey, h.Stderr)

--- a/internal/auth/oauth_refresh_rejection_flow_test.go
+++ b/internal/auth/oauth_refresh_rejection_flow_test.go
@@ -1,0 +1,77 @@
+package auth
+
+import (
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rest-sh/restish/v2/auth"
+)
+
+// Supabase GoTrue rejects a dead refresh token with 400
+// {"error_code":"refresh_token_not_found"} instead of {"error":"invalid_grant"}.
+// That must clear the cached token and fall through to interactive auth, not
+// fail every request until a manual logout.
+func TestDeviceCodeProviderRefreshRejectionFallsThrough(t *testing.T) {
+	cache := auth.NewTokenCache(filepath.Join(t.TempDir(), "tokens.cbor"))
+	if err := cache.Set("svc:default", auth.CachedToken{
+		AccessToken:  "expired-token",
+		RefreshToken: "rejected-refresh",
+		Expiry:       time.Now().Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+
+	var deviceStarted bool
+	var stderr strings.Builder
+	h := &DeviceCode{
+		Cache:  cache,
+		Stderr: &stderr,
+		HTTPClient: testHTTPClient(func(r *http.Request) (*http.Response, error) {
+			switch r.URL.String() {
+			case "https://auth.example.com/token":
+				if err := r.ParseForm(); err != nil {
+					t.Fatalf("ParseForm: %v", err)
+				}
+				if r.FormValue("grant_type") == "refresh_token" {
+					return testResponse(400, "application/json", `{"code":400,"error_code":"refresh_token_not_found","msg":"Invalid Refresh Token: Refresh Token Not Found"}`), nil
+				}
+				return testResponse(200, "application/json", `{"access_token":"device-token","token_type":"bearer","expires_in":3600}`), nil
+			case "https://auth.example.com/device":
+				deviceStarted = true
+				return testResponse(200, "application/json", `{
+					"device_code":"device-123",
+					"user_code":"ABCD-EFGH",
+					"verification_uri":"https://verify.example.com",
+					"interval":1,
+					"expires_in":60
+				}`), nil
+			default:
+				t.Fatalf("unexpected URL %q", r.URL.String())
+				return nil, nil
+			}
+		}),
+	}
+
+	req, _ := http.NewRequest("GET", "https://api.example.com", nil)
+	params := map[string]string{
+		"_cache_key":               "svc:default",
+		"client_id":                "id1",
+		"device_authorization_url": "https://auth.example.com/device",
+		"token_url":                "https://auth.example.com/token",
+	}
+	if err := h.OnRequest(req, params); err != nil {
+		t.Fatalf("OnRequest: %v", err)
+	}
+	if !deviceStarted {
+		t.Fatal("expected provider refresh rejection to fall through to device flow")
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer device-token" {
+		t.Fatalf("Authorization = %q", got)
+	}
+	if !strings.Contains(stderr.String(), "cleared cached token") {
+		t.Fatalf("expected cache clear warning, got %q", stderr.String())
+	}
+}

--- a/internal/auth/oauth_refresh_rejection_test.go
+++ b/internal/auth/oauth_refresh_rejection_test.go
@@ -1,0 +1,30 @@
+package auth
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsRefreshTokenRejected(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"rfc invalid_grant", parseTokenEndpointError(400, []byte(`{"error":"invalid_grant"}`)), true},
+		{"gotrue refresh_token_not_found", parseTokenEndpointError(400, []byte(`{"code":400,"error_code":"refresh_token_not_found","msg":"Invalid Refresh Token: Refresh Token Not Found"}`)), true},
+		{"gotrue refresh_token_already_used", parseTokenEndpointError(400, []byte(`{"error_code":"refresh_token_already_used"}`)), true},
+		{"gotrue session_expired", parseTokenEndpointError(403, []byte(`{"error_code":"session_expired"}`)), true},
+		{"rfc invalid_client", parseTokenEndpointError(401, []byte(`{"error":"invalid_client"}`)), false},
+		{"gotrue unrelated code", parseTokenEndpointError(400, []byte(`{"error_code":"validation_failed"}`)), false},
+		{"server error", parseTokenEndpointError(502, []byte(`upstream down`)), false},
+		{"network", errors.New("dial failed"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRefreshTokenRejected(tc.err); got != tc.want {
+				t.Fatalf("isRefreshTokenRejected(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The refresh path falls back to interactive auth only on an RFC 6749 `{"error":"invalid_grant"}` (`internal/auth/oauth_authcode.go` / `oauth_device_code.go`). Supabase GoTrue answers a dead refresh token with:

```
400 {"code":400,"error_code":"refresh_token_not_found","msg":"Invalid Refresh Token: Refresh Token Not Found"}
```

`error` is never set, so `parseTokenEndpointError` yields an empty `ErrorCode`, the check fails, and Restish prints `OAuth refresh failed: …` and returns the error — on **every** request, until the user runs `auth logout` by hand. Reproduced with an embedded CLI on v2.3.0 (macOS and Windows) after the refresh token was rotated away by a second login.

This parses the provider `error_code` field alongside `error`, and treats the GoTrue codes that mean the refresh token or its session is gone (`refresh_token_not_found`, `refresh_token_already_used`, `session_not_found`, `session_expired`) exactly like `invalid_grant`: clear the cached token, fall through to the browser/device flow. Network errors, 5xx, and unrelated codes behave as before (`TestAuthCode_RefreshNetworkFailureDoesNotFallback` still passes).

Tests: `TestIsRefreshTokenRejected` (table) and `TestDeviceCodeProviderRefreshRejectionFallsThrough` (flow, mirrors the existing invalid_grant one).
