### PR TITLE
feat(plugin): route structured command progress

### DIFF
--- a/docs/design/020-command-plugins.md
+++ b/docs/design/020-command-plugins.md
@@ -89,12 +89,26 @@ The current implementation handles these message types:
 - `api-spec` to ask Restish to resolve a registered API spec
 - `response` to ask Restish to format and print a normalized response
 - `stdout-data` and `stderr-data` to write raw bytes directly
-- `progress`, `spinner`, and `log` to print status text on stderr
+- `progress` to report structured or plain-text status on stderr
+- `spinner` and `log` to print status text on stderr
 - `warn` to print a warning-prefixed message
 - `done` to terminate with an exit code
 
 Prompt/confirm style interactions are also valid protocol concepts when a
 plugin needs host-owned prompting behavior.
+
+`progress` always includes `text` as a plain fallback. It may also include
+`id`, `label`, `state`, `current`, `total`, and `message`. When a streaming
+formatter named `progress` is registered and the record has an `id` or `label`,
+the host sends those structured fields through one formatter session for the
+command. Otherwise it prints `text` as a normal stderr line. Formatter startup
+or rendering failures warn once and fall back to `text`; they do not fail the
+command. The host closes an active formatter session whenever the command ends.
+
+The fields are additive to the v2 CBOR contract. New plugins must keep `text`
+meaningful because older hosts ignore the structured fields, and installations
+without a progress formatter use it directly. Plugins must not discover or
+execute sibling plugins themselves.
 
 ### Messages From Restish To Plugin
 

--- a/docs/design/020-command-plugins.md
+++ b/docs/design/020-command-plugins.md
@@ -98,7 +98,7 @@ Prompt/confirm style interactions are also valid protocol concepts when a
 plugin needs host-owned prompting behavior.
 
 `progress` always includes `text` as a plain fallback. It may also include
-`id`, `label`, `state`, `current`, `total`, and `message`. When a streaming
+`id`, `label`, `state`, `current`, `total`, `unit`, and `message`. When a streaming
 formatter named `progress` is registered and the record has an `id` or `label`,
 the host sends those structured fields through one formatter session for the
 command. Otherwise it prints `text` as a normal stderr line. Formatter startup

--- a/internal/cli/command_plugin_handlers.go
+++ b/internal/cli/command_plugin_handlers.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c *CLI) handleCommandPluginMessage(cmd *cobra.Command, requestCtx context.Context, writer *commandPluginWriter, requestWG *sync.WaitGroup, msgType string, raw []byte) (bool, error) {
+func (c *CLI) handleCommandPluginMessage(cmd *cobra.Command, requestCtx context.Context, writer *commandPluginWriter, requestWG *sync.WaitGroup, progress *commandProgressRenderer, msgType string, raw []byte) (bool, error) {
 	if len(raw) > maxCommandPluginInboundMessageBytes {
 		return false, fmt.Errorf("command plugin: message %s exceeded %d bytes", msgType, maxCommandPluginInboundMessageBytes)
 	}
@@ -127,6 +127,15 @@ func (c *CLI) handleCommandPluginMessage(cmd *cobra.Command, requestCtx context.
 		var msg pluginwire.ProgressMsg
 		if err := decodeCommandPluginMessage(msgType, raw, &msg); err != nil {
 			return false, err
+		}
+		if progress != nil && (msg.ID != "" || msg.Label != "") {
+			handled, err := progress.Write(msg)
+			if err != nil {
+				writeDiagnostic(cmd.ErrOrStderr(), diagnosticWarn, "warning", "progress formatter unavailable: %v", err)
+			}
+			if handled {
+				break
+			}
 		}
 		if msg.Text != "" {
 			fmt.Fprintln(cmd.ErrOrStderr(), msg.Text)

--- a/internal/cli/command_plugin_internal_test.go
+++ b/internal/cli/command_plugin_internal_test.go
@@ -36,7 +36,7 @@ func TestHandleCommandPluginMessageRejectsMalformedDone(t *testing.T) {
 		t.Fatalf("marshal: %v", err)
 	}
 
-	done, gotErr := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, "done", raw)
+	done, gotErr := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, nil, "done", raw)
 	if !done {
 		t.Fatal("expected malformed done message to stop processing")
 	}
@@ -63,7 +63,7 @@ func TestHandleCommandPluginMessageRejectsOversizedStdoutData(t *testing.T) {
 		t.Fatalf("marshal: %v", err)
 	}
 
-	done, gotErr := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, pluginwire.MsgTypeStdoutData, raw)
+	done, gotErr := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, nil, pluginwire.MsgTypeStdoutData, raw)
 	if done {
 		t.Fatal("stdout-data should not mark command plugin done")
 	}
@@ -93,7 +93,7 @@ func TestHandleCommandPluginMessageRejectsOversizedStderrData(t *testing.T) {
 		t.Fatalf("marshal: %v", err)
 	}
 
-	done, gotErr := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, pluginwire.MsgTypeStderrData, raw)
+	done, gotErr := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, nil, pluginwire.MsgTypeStderrData, raw)
 	if done {
 		t.Fatal("stderr-data should not mark command plugin done")
 	}

--- a/internal/cli/command_plugin_progress.go
+++ b/internal/cli/command_plugin_progress.go
@@ -1,0 +1,154 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/rest-sh/restish/v2/internal/output"
+	pluginwire "github.com/rest-sh/restish/v2/plugin"
+	"github.com/spf13/cobra"
+)
+
+type commandProgressRenderer struct {
+	formatter  output.ValueStreamFormatter
+	stream     output.ValueStream
+	cmd        *cobra.Command
+	ctx        context.Context
+	cancel     context.CancelFunc
+	subprocess bool
+	disabled   bool
+	fallback   []string
+	bytes      int
+}
+
+func (c *CLI) newCommandProgressRenderer(cmd *cobra.Command) *commandProgressRenderer {
+	formatter, ok := c.formatters["progress"].(output.ValueStreamFormatter)
+	if !ok {
+		return nil
+	}
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	subprocess := false
+	if pluginFormatter, ok := formatter.(*output.PluginFormatter); ok {
+		clone := *pluginFormatter
+		clone.Context = ctx
+		formatter = &clone
+		subprocess = true
+	}
+	return &commandProgressRenderer{
+		formatter:  formatter,
+		cmd:        cmd,
+		ctx:        ctx,
+		cancel:     cancel,
+		subprocess: subprocess,
+	}
+}
+
+func (r *commandProgressRenderer) Write(msg pluginwire.ProgressMsg) (bool, error) {
+	if r.disabled {
+		return false, nil
+	}
+	if (msg.Current == nil) != (msg.Total == nil) || msg.Current != nil && (*msg.Current < 0 || *msg.Total <= 0 || *msg.Current > *msg.Total) {
+		return false, nil
+	}
+	if msg.Text != "" && r.bytes+len(msg.Text)+1 > maxCommandPluginDataBytes {
+		err := r.closeStream()
+		r.disabled = true
+		return false, err
+	}
+	if r.stream == nil {
+		// Command stderr is not coordinated with formatter redraws yet, so keep
+		// this session line-oriented even when stderr is a terminal.
+		stream, err := r.formatter.StartValueStream(r.cmd.ErrOrStderr(), &output.Response{}, false)
+		if err != nil {
+			r.disabled = true
+			return false, err
+		}
+		r.stream = stream
+	}
+	record := map[string]any{
+		"id":      msg.ID,
+		"label":   msg.Label,
+		"state":   msg.State,
+		"current": msg.Current,
+		"total":   msg.Total,
+		"message": msg.Message,
+	}
+	stream := r.stream
+	if err := r.run(func() error { return stream.WriteValue(record) }); err != nil {
+		var closeErr error
+		if r.ctx.Err() != nil {
+			if r.subprocess {
+				closeErr = stream.Close()
+			}
+			r.stream = nil
+			r.replayFallback()
+		} else {
+			closeErr = r.closeStream()
+		}
+		r.disabled = true
+		return false, errors.Join(err, closeErr)
+	}
+	if msg.Text != "" {
+		r.fallback = append(r.fallback, msg.Text)
+		r.bytes += len(msg.Text) + 1
+	}
+	return true, nil
+}
+
+func (r *commandProgressRenderer) Close() error {
+	defer r.cancel()
+	return r.closeStream()
+}
+
+func (r *commandProgressRenderer) closeStream() error {
+	if r.stream == nil {
+		return nil
+	}
+	err := r.run(r.stream.Close)
+	r.stream = nil
+	if err != nil {
+		r.replayFallback()
+	} else {
+		r.fallback = nil
+		r.bytes = 0
+	}
+	return err
+}
+
+func (r *commandProgressRenderer) replayFallback() {
+	for _, text := range r.fallback {
+		fmt.Fprintln(r.cmd.ErrOrStderr(), text)
+	}
+	r.fallback = nil
+	r.bytes = 0
+}
+
+func (r *commandProgressRenderer) run(fn func() error) error {
+	done := make(chan error, 1)
+	go func() { done <- fn() }()
+	timeout := commandPluginShutdownGrace()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case err := <-done:
+		return err
+	case <-r.ctx.Done():
+		r.cancel()
+		if r.subprocess {
+			return errors.Join(r.ctx.Err(), <-done)
+		}
+		return r.ctx.Err()
+	case <-timer.C:
+		r.cancel()
+		if r.subprocess {
+			return errors.Join(fmt.Errorf("timed out after %s", timeout), <-done)
+		}
+		return fmt.Errorf("timed out after %s", timeout)
+	}
+}

--- a/internal/cli/command_plugin_progress.go
+++ b/internal/cli/command_plugin_progress.go
@@ -77,6 +77,7 @@ func (r *commandProgressRenderer) Write(msg pluginwire.ProgressMsg) (bool, error
 		"state":   msg.State,
 		"current": msg.Current,
 		"total":   msg.Total,
+		"unit":    msg.Unit,
 		"message": msg.Message,
 	}
 	stream := r.stream

--- a/internal/cli/command_plugin_progress_test.go
+++ b/internal/cli/command_plugin_progress_test.go
@@ -1,0 +1,209 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/rest-sh/restish/v2/internal/output"
+	pluginwire "github.com/rest-sh/restish/v2/plugin"
+	"github.com/spf13/cobra"
+)
+
+type recordingProgressFormatter struct {
+	startErr error
+	starts   int
+	color    bool
+	stream   recordingProgressStream
+}
+
+func (f *recordingProgressFormatter) Format(io.Writer, *output.Response, bool) error {
+	return nil
+}
+
+func (f *recordingProgressFormatter) StartValueStream(_ io.Writer, _ *output.Response, color bool) (output.ValueStream, error) {
+	f.starts++
+	f.color = color
+	if f.startErr != nil {
+		return nil, f.startErr
+	}
+	return &f.stream, nil
+}
+
+type recordingProgressStream struct {
+	values     []any
+	closed     bool
+	closeErr   error
+	writeBlock <-chan struct{}
+	writeDone  chan<- struct{}
+}
+
+func (s *recordingProgressStream) WriteValue(value any) error {
+	if s.writeDone != nil {
+		defer close(s.writeDone)
+	}
+	if s.writeBlock != nil {
+		<-s.writeBlock
+	}
+	s.values = append(s.values, value)
+	return nil
+}
+
+func (s *recordingProgressStream) Close() error {
+	s.closed = true
+	return s.closeErr
+}
+
+func TestStructuredCommandProgressUsesOneFormatterSession(t *testing.T) {
+	var stderr bytes.Buffer
+	formatter := &recordingProgressFormatter{}
+	cli := &CLI{Stderr: &stderr, formatters: map[string]output.Formatter{"progress": formatter}}
+	cmd := &cobra.Command{Use: "test"}
+	cmd.SetErr(&stderr)
+	renderer := cli.newCommandProgressRenderer(cmd)
+
+	for current := int64(1); current <= 2; current++ {
+		total := int64(2)
+		msg := pluginwire.ProgressMsg{Type: pluginwire.MsgTypeProgress, Text: "fallback", ID: "workflow", State: "running", Current: &current, Total: &total}
+		raw, err := cbor.Marshal(msg)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if _, err := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, renderer, pluginwire.MsgTypeProgress, raw); err != nil {
+			t.Fatalf("handleCommandPluginMessage: %v", err)
+		}
+	}
+	if err := renderer.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if formatter.starts != 1 || formatter.color || len(formatter.stream.values) != 2 || !formatter.stream.closed {
+		t.Fatalf("formatter starts=%d color=%t values=%d closed=%t", formatter.starts, formatter.color, len(formatter.stream.values), formatter.stream.closed)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("fallback written despite formatter: %q", stderr.String())
+	}
+}
+
+func TestStructuredCommandProgressFallsBackWithoutFormatter(t *testing.T) {
+	var stderr bytes.Buffer
+	cli := &CLI{Stderr: &stderr}
+	cmd := &cobra.Command{Use: "test"}
+	cmd.SetErr(&stderr)
+	msg := pluginwire.ProgressMsg{Type: pluginwire.MsgTypeProgress, Text: "Running step 1 of 2", ID: "workflow"}
+	raw, err := cbor.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if _, err := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, cli.newCommandProgressRenderer(cmd), pluginwire.MsgTypeProgress, raw); err != nil {
+		t.Fatalf("handleCommandPluginMessage: %v", err)
+	}
+	if got := stderr.String(); got != "Running step 1 of 2\n" {
+		t.Fatalf("stderr = %q", got)
+	}
+}
+
+func TestInvalidStructuredCommandProgressFallsBack(t *testing.T) {
+	var stderr bytes.Buffer
+	formatter := &recordingProgressFormatter{}
+	cli := &CLI{Stderr: &stderr, formatters: map[string]output.Formatter{"progress": formatter}}
+	cmd := &cobra.Command{Use: "test"}
+	cmd.SetErr(&stderr)
+	renderer := cli.newCommandProgressRenderer(cmd)
+	current := int64(1)
+	msg := pluginwire.ProgressMsg{Type: pluginwire.MsgTypeProgress, Text: "fallback", ID: "workflow", Current: &current}
+	raw, err := cbor.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if _, err := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, renderer, pluginwire.MsgTypeProgress, raw); err != nil {
+		t.Fatalf("handleCommandPluginMessage: %v", err)
+	}
+	if formatter.starts != 0 || stderr.String() != "fallback\n" {
+		t.Fatalf("formatter starts=%d stderr=%q", formatter.starts, stderr.String())
+	}
+}
+
+func TestStructuredCommandProgressFallsBackAfterFormatterFailure(t *testing.T) {
+	var stderr bytes.Buffer
+	formatter := &recordingProgressFormatter{startErr: errors.New("boom")}
+	cli := &CLI{Stderr: &stderr, formatters: map[string]output.Formatter{"progress": formatter}}
+	cmd := &cobra.Command{Use: "test"}
+	cmd.SetErr(&stderr)
+	renderer := cli.newCommandProgressRenderer(cmd)
+	msg := pluginwire.ProgressMsg{Type: pluginwire.MsgTypeProgress, Text: "fallback", ID: "workflow"}
+	raw, err := cbor.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	for range 2 {
+		if _, err := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, renderer, pluginwire.MsgTypeProgress, raw); err != nil {
+			t.Fatalf("handleCommandPluginMessage: %v", err)
+		}
+	}
+	if formatter.starts != 1 {
+		t.Fatalf("formatter starts = %d, want 1", formatter.starts)
+	}
+	if got := stderr.String(); strings.Count(got, "progress formatter unavailable") != 1 || strings.Count(got, "fallback\n") != 2 {
+		t.Fatalf("stderr = %q", got)
+	}
+}
+
+func TestStructuredCommandProgressReplaysFallbackAfterCloseFailure(t *testing.T) {
+	var stderr bytes.Buffer
+	formatter := &recordingProgressFormatter{}
+	formatter.stream.closeErr = errors.New("boom")
+	cli := &CLI{Stderr: &stderr, formatters: map[string]output.Formatter{"progress": formatter}}
+	cmd := &cobra.Command{Use: "test"}
+	cmd.SetErr(&stderr)
+	renderer := cli.newCommandProgressRenderer(cmd)
+	msg := pluginwire.ProgressMsg{Type: pluginwire.MsgTypeProgress, Text: "fallback", ID: "workflow"}
+	raw, err := cbor.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if _, err := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, renderer, pluginwire.MsgTypeProgress, raw); err != nil {
+		t.Fatalf("handleCommandPluginMessage: %v", err)
+	}
+	if err := renderer.Close(); err == nil {
+		t.Fatal("Close returned nil")
+	}
+	if got := stderr.String(); got != "fallback\n" {
+		t.Fatalf("stderr = %q", got)
+	}
+}
+
+func TestStructuredCommandProgressBoundsBlockedFormatter(t *testing.T) {
+	t.Setenv("RSH_COMMAND_PLUGIN_SHUTDOWN_GRACE", "20ms")
+	var stderr bytes.Buffer
+	block := make(chan struct{})
+	done := make(chan struct{})
+	formatter := &recordingProgressFormatter{}
+	formatter.stream.writeBlock = block
+	formatter.stream.writeDone = done
+	cli := &CLI{Stderr: &stderr, formatters: map[string]output.Formatter{"progress": formatter}}
+	cmd := &cobra.Command{Use: "test"}
+	cmd.SetErr(&stderr)
+	renderer := cli.newCommandProgressRenderer(cmd)
+	msg := pluginwire.ProgressMsg{Type: pluginwire.MsgTypeProgress, Text: "fallback", ID: "workflow"}
+	raw, err := cbor.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if _, err := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, renderer, pluginwire.MsgTypeProgress, raw); err != nil {
+		t.Fatalf("handleCommandPluginMessage: %v", err)
+	}
+	close(block)
+	<-done
+	if got := stderr.String(); !strings.Contains(got, "timed out after 20ms") || !strings.Contains(got, "fallback\n") {
+		t.Fatalf("stderr = %q", got)
+	}
+}

--- a/internal/cli/command_plugin_runtime.go
+++ b/internal/cli/command_plugin_runtime.go
@@ -194,6 +194,7 @@ func (c *CLI) runCommandPlugin(cmd *cobra.Command, pluginPath string, decl plugi
 	requestCtx, cancelRequests := context.WithCancel(cmd.Context())
 	defer cancelRequests()
 	dec := pluginwire.NewDecoder(stdoutPipe)
+	progress := c.newCommandProgressRenderer(cmd)
 	for {
 		raw, err := dec.ReadRaw()
 		if err != nil {
@@ -211,7 +212,7 @@ func (c *CLI) runCommandPlugin(cmd *cobra.Command, pluginPath string, decl plugi
 			break
 		}
 
-		done, err := c.handleCommandPluginMessage(cmd, requestCtx, writer, &requestWG, pluginwire.MessageType(raw), raw)
+		done, err := c.handleCommandPluginMessage(cmd, requestCtx, writer, &requestWG, progress, pluginwire.MessageType(raw), raw)
 		if err != nil {
 			loopErr = err
 			break
@@ -225,6 +226,11 @@ func (c *CLI) runCommandPlugin(cmd *cobra.Command, pluginPath string, decl plugi
 	close(cancelWatchDone)
 	close(stopCh)
 	cancelRequests()
+	if progress != nil {
+		if err := progress.Close(); err != nil {
+			writeDiagnostic(cmd.ErrOrStderr(), diagnosticWarn, "warning", "progress formatter cleanup failed: %v", err)
+		}
+	}
 	stderrWriter.Flush()
 	if loopErr != nil {
 		_ = stdinPipe.Close()

--- a/plugin/client.go
+++ b/plugin/client.go
@@ -510,6 +510,12 @@ func (c *CommandClient) Progress(text string) error {
 	return c.WriteMessage(ProgressMsg{Type: MsgTypeProgress, Text: text})
 }
 
+// ProgressUpdate sends structured progress with Text as its plain fallback.
+func (c *CommandClient) ProgressUpdate(msg ProgressMsg) error {
+	msg.Type = MsgTypeProgress
+	return c.WriteMessage(msg)
+}
+
 // Done signals that the plugin has finished.  exitCode 0 means success; any
 // other value causes the host to exit with that code.
 func (c *CommandClient) Done(exitCode int) error {

--- a/plugin/client_test.go
+++ b/plugin/client_test.go
@@ -44,6 +44,7 @@ func TestCommandClientProgressUpdateWritesStructuredProgress(t *testing.T) {
 		State:   "running",
 		Current: &current,
 		Total:   &total,
+		Unit:    "steps",
 		Message: "fetch owner",
 	}); err != nil {
 		t.Fatalf("ProgressUpdate: %v", err)
@@ -53,7 +54,7 @@ func TestCommandClientProgressUpdateWritesStructuredProgress(t *testing.T) {
 	if err := NewDecoder(bytes.NewReader(out.Bytes())).ReadMessage(&msg); err != nil {
 		t.Fatalf("ReadMessage: %v", err)
 	}
-	if msg.Type != MsgTypeProgress || msg.Text != "Running step 2 of 4" || msg.ID != "workflow" || msg.Label != "Run workflow" || msg.State != "running" || msg.Current == nil || *msg.Current != 2 || msg.Total == nil || *msg.Total != 4 || msg.Message != "fetch owner" {
+	if msg.Type != MsgTypeProgress || msg.Text != "Running step 2 of 4" || msg.ID != "workflow" || msg.Label != "Run workflow" || msg.State != "running" || msg.Current == nil || *msg.Current != 2 || msg.Total == nil || *msg.Total != 4 || msg.Unit != "steps" || msg.Message != "fetch owner" {
 		t.Fatalf("message = %#v", msg)
 	}
 }

--- a/plugin/client_test.go
+++ b/plugin/client_test.go
@@ -33,6 +33,48 @@ func TestCommandClientProgressWritesProgressMessage(t *testing.T) {
 	}
 }
 
+func TestCommandClientProgressUpdateWritesStructuredProgress(t *testing.T) {
+	var out bytes.Buffer
+	client := NewCommandClient(bytes.NewReader(nil), &out)
+	current, total := int64(2), int64(4)
+	if err := client.ProgressUpdate(ProgressMsg{
+		Text:    "Running step 2 of 4",
+		ID:      "workflow",
+		Label:   "Run workflow",
+		State:   "running",
+		Current: &current,
+		Total:   &total,
+		Message: "fetch owner",
+	}); err != nil {
+		t.Fatalf("ProgressUpdate: %v", err)
+	}
+
+	var msg ProgressMsg
+	if err := NewDecoder(bytes.NewReader(out.Bytes())).ReadMessage(&msg); err != nil {
+		t.Fatalf("ReadMessage: %v", err)
+	}
+	if msg.Type != MsgTypeProgress || msg.Text != "Running step 2 of 4" || msg.ID != "workflow" || msg.Label != "Run workflow" || msg.State != "running" || msg.Current == nil || *msg.Current != 2 || msg.Total == nil || *msg.Total != 4 || msg.Message != "fetch owner" {
+		t.Fatalf("message = %#v", msg)
+	}
+}
+
+func TestStructuredProgressRetainsLegacyTextFallback(t *testing.T) {
+	var out bytes.Buffer
+	if err := WriteMessage(&out, ProgressMsg{Type: MsgTypeProgress, Text: "working", ID: "workflow"}); err != nil {
+		t.Fatalf("WriteMessage: %v", err)
+	}
+	var legacy struct {
+		Type string `cbor:"type"`
+		Text string `cbor:"text"`
+	}
+	if err := NewDecoder(bytes.NewReader(out.Bytes())).ReadMessage(&legacy); err != nil {
+		t.Fatalf("ReadMessage: %v", err)
+	}
+	if legacy.Type != MsgTypeProgress || legacy.Text != "working" {
+		t.Fatalf("legacy message = %#v", legacy)
+	}
+}
+
 func TestCommandClientWriteStdoutWritesStdoutDataMessage(t *testing.T) {
 	var out bytes.Buffer
 	client := NewCommandClient(bytes.NewReader(nil), &out)

--- a/plugin/doc.go
+++ b/plugin/doc.go
@@ -46,7 +46,7 @@
 //   - ListAPIsMsg / ListProfilesMsg for config discovery
 //   - ConfigReadMsg for effective API/profile/plugin config
 //   - PromptMsg / ConfirmMsg for user interaction
-//   - ResponseMsg, StdoutDataMsg, StderrDataMsg, WarnMsg, and DoneMsg for output
+//   - ResponseMsg, StdoutDataMsg, StderrDataMsg, WarnMsg, ProgressMsg, and DoneMsg for output
 //
 // For simple command plugins, plugin.Run and CommandClient are usually enough.
 //

--- a/plugin/messages.go
+++ b/plugin/messages.go
@@ -317,6 +317,7 @@ type ProgressMsg struct {
 	State   string `cbor:"state,omitempty"`
 	Current *int64 `cbor:"current,omitempty"`
 	Total   *int64 `cbor:"total,omitempty"`
+	Unit    string `cbor:"unit,omitempty"`
 	Message string `cbor:"message,omitempty"`
 }
 

--- a/plugin/messages.go
+++ b/plugin/messages.go
@@ -307,10 +307,17 @@ type WarnMsg struct {
 	Text string `cbor:"text"`
 }
 
-// ProgressMsg prints an informational progress line on the host stderr.
+// ProgressMsg reports command progress on the host stderr. Text is the plain
+// fallback when no structured progress formatter is available.
 type ProgressMsg struct {
-	Type string `cbor:"type"`
-	Text string `cbor:"text"`
+	Type    string `cbor:"type"`
+	Text    string `cbor:"text"`
+	ID      string `cbor:"id,omitempty"`
+	Label   string `cbor:"label,omitempty"`
+	State   string `cbor:"state,omitempty"`
+	Current *int64 `cbor:"current,omitempty"`
+	Total   *int64 `cbor:"total,omitempty"`
+	Message string `cbor:"message,omitempty"`
 }
 
 // SpinnerMsg requests spinner-style status text on the host stderr.

--- a/site/content/en/docs/plugins/command-plugins.md
+++ b/site/content/en/docs/plugins/command-plugins.md
@@ -101,8 +101,8 @@ Older Restish versions ignore the additional fields and continue printing
 
 `current` and `total` are optional, but must be supplied together. Use the same
 `id` for updates to one task, and send a terminal `state` such as `success` or
-`failed` on its final update. Progress remains on stderr and never changes the
-command's primary stdout result.
+`failed` on its final update. Set `unit` when the count is not steps. Progress
+remains on stderr and never changes the command's primary stdout result.
 
 ## Lifecycle
 

--- a/site/content/en/docs/plugins/command-plugins.md
+++ b/site/content/en/docs/plugins/command-plugins.md
@@ -75,6 +75,35 @@ Non-Go plugins can send the same message families directly:
 }
 ```
 
+## Structured Progress
+
+Use `Progress` for a plain status line. Use `ProgressUpdate` when a command can
+report a stable identity, state, and optional step count:
+
+```go
+current, total := int64(2), int64(4)
+err := c.ProgressUpdate(plugin.ProgressMsg{
+  Text:    "Running step 2 of 4: fetch owner",
+  ID:      "workflow",
+  Label:   "Run workflow",
+  State:   "running",
+  Current: &current,
+  Total:   &total,
+  Message: "fetch owner",
+})
+```
+
+`Text` is always the fallback. Restish prints it on stderr when no streaming
+formatter named `progress` is installed. When that formatter is available,
+Restish keeps one formatter session open and sends it the structured records.
+Older Restish versions ignore the additional fields and continue printing
+`Text`.
+
+`current` and `total` are optional, but must be supplied together. Use the same
+`id` for updates to one task, and send a terminal `state` such as `success` or
+`failed` on its final update. Progress remains on stderr and never changes the
+command's primary stdout result.
+
 ## Lifecycle
 
 1. The plugin declares commands during startup discovery.

--- a/site/content/en/docs/reference/plugin-messages.md
+++ b/site/content/en/docs/reference/plugin-messages.md
@@ -630,7 +630,7 @@ CBOR: `text`; type: `string`; required: yes
 
 ### `ProgressMsg`
 
-ProgressMsg prints an informational progress line on the host stderr.
+ProgressMsg reports command progress on the host stderr. Text is the plain fallback when no structured progress formatter is available.
 
 **`Type`**
 
@@ -639,6 +639,30 @@ CBOR: `type`; type: `string`; required: yes
 **`Text`**
 
 CBOR: `text`; type: `string`; required: yes
+
+**`ID`**
+
+CBOR: `id`; type: `string`; required: no
+
+**`Label`**
+
+CBOR: `label`; type: `string`; required: no
+
+**`State`**
+
+CBOR: `state`; type: `string`; required: no
+
+**`Current`**
+
+CBOR: `current`; type: `*int64`; required: no
+
+**`Total`**
+
+CBOR: `total`; type: `*int64`; required: no
+
+**`Message`**
+
+CBOR: `message`; type: `string`; required: no
 
 
 ### `SpinnerMsg`

--- a/site/content/en/docs/reference/plugin-messages.md
+++ b/site/content/en/docs/reference/plugin-messages.md
@@ -660,6 +660,10 @@ CBOR: `current`; type: `*int64`; required: no
 
 CBOR: `total`; type: `*int64`; required: no
 
+**`Unit`**
+
+CBOR: `unit`; type: `string`; required: no
+
 **`Message`**
 
 CBOR: `message`; type: `string`; required: no


### PR DESCRIPTION
## Summary

- extends the existing `progress` message with optional task identity, state, step counts, and status details
- routes structured records through one installed streaming formatter named `progress`, with bounded lifecycle and plain stderr fallback
- documents the additive v2 wire contract and adds compatibility, routing, failure, cleanup, and timeout coverage

Closes #430

## Behavior

I built the same small v2 command plugin for both runs. It sends two `progress` CBOR maps with `text`, `id`, `label`, `state`, `current`, `total`, and `message`. The producer uses `CommandClient.WriteMessage`, so it also builds against Restish v2.3.0:

```go
for current, message := range []string{"prepare", "complete"} {
    step := current + 1
    err := client.WriteMessage(map[string]any{
        "type": plugin.MsgTypeProgress, "text": fmt.Sprintf("Step %d of 2: %s", step, message),
        "id": "workflow", "label": "Run workflow",
        "state": []string{"running", "success"}[current],
        "current": step, "total": 2, "message": message,
    })
    if err != nil { return err }
}
```

With that command plugin and `restish-progress` installed:

```console
$ restish-before status 2>&1
Step 1 of 2: prepare
Step 2 of 2: complete

$ restish-after status 2>&1
50% ████████████░░░░░░░░░░░░  Run workflow  1/2 steps  running: prepare
100% ████████████████████████  Run workflow  2/2 steps  success: complete
```

Removing `restish-progress` from the same patched installation preserves the fallback:

```console
$ restish plugin remove restish-progress
Removed plugin restish-progress
$ restish-after status 2>&1
Step 1 of 2: prepare
Step 2 of 2: complete
```

The local CI-parity run passed unit and integration tests, the race detector, vet, all five binary builds, generated-doc validation, docs links and examples, social image generation, and the minified Hugo build.

---

> [!NOTE]
> AI assistance: documentation, test scaffolding, PR description.
