### PR TITLE
feat: show progress for raw downloads

### DIFF
--- a/docs/design/020-command-plugins.md
+++ b/docs/design/020-command-plugins.md
@@ -89,12 +89,26 @@ The current implementation handles these message types:
 - `api-spec` to ask Restish to resolve a registered API spec
 - `response` to ask Restish to format and print a normalized response
 - `stdout-data` and `stderr-data` to write raw bytes directly
-- `progress`, `spinner`, and `log` to print status text on stderr
+- `progress` to report structured or plain-text status on stderr
+- `spinner` and `log` to print status text on stderr
 - `warn` to print a warning-prefixed message
 - `done` to terminate with an exit code
 
 Prompt/confirm style interactions are also valid protocol concepts when a
 plugin needs host-owned prompting behavior.
+
+`progress` always includes `text` as a plain fallback. It may also include
+`id`, `label`, `state`, `current`, `total`, and `message`. When a streaming
+formatter named `progress` is registered and the record has an `id` or `label`,
+the host sends those structured fields through one formatter session for the
+command. Otherwise it prints `text` as a normal stderr line. Formatter startup
+or rendering failures warn once and fall back to `text`; they do not fail the
+command. The host closes an active formatter session whenever the command ends.
+
+The fields are additive to the v2 CBOR contract. New plugins must keep `text`
+meaningful because older hosts ignore the structured fields, and installations
+without a progress formatter use it directly. Plugins must not discover or
+execute sibling plugins themselves.
 
 ### Messages From Restish To Plugin
 

--- a/docs/design/020-command-plugins.md
+++ b/docs/design/020-command-plugins.md
@@ -98,7 +98,7 @@ Prompt/confirm style interactions are also valid protocol concepts when a
 plugin needs host-owned prompting behavior.
 
 `progress` always includes `text` as a plain fallback. It may also include
-`id`, `label`, `state`, `current`, `total`, and `message`. When a streaming
+`id`, `label`, `state`, `current`, `total`, `unit`, and `message`. When a streaming
 formatter named `progress` is registered and the record has an `id` or `label`,
 the host sends those structured fields through one formatter session for the
 command. Otherwise it prints `text` as a normal stderr line. Formatter startup

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -81,6 +81,8 @@ type testHooks struct {
 	AuthHookFunc func(apiName, profileName string, rawParams map[string]string, secretKeys map[string]bool, req *http.Request) error
 	// StdoutIsTerminal overrides terminal detection in tests.
 	StdoutIsTerminal func(io.Writer) bool
+	// StderrIsTerminal overrides terminal detection in tests.
+	StderrIsTerminal func(io.Writer) bool
 }
 
 func (c *CLI) stdoutIsTerminal() bool {
@@ -88,6 +90,13 @@ func (c *CLI) stdoutIsTerminal() bool {
 		return c.hooks.StdoutIsTerminal(c.Stdout)
 	}
 	return output.IsTerminal(c.Stdout)
+}
+
+func (c *CLI) stderrIsTerminal() bool {
+	if c.hooks.StderrIsTerminal != nil {
+		return c.hooks.StderrIsTerminal(c.Stderr)
+	}
+	return output.IsTerminal(c.Stderr)
 }
 
 // CLI holds all state for a Restish instance. Using a struct instead of

--- a/internal/cli/command_plugin_handlers.go
+++ b/internal/cli/command_plugin_handlers.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c *CLI) handleCommandPluginMessage(cmd *cobra.Command, requestCtx context.Context, writer *commandPluginWriter, requestWG *sync.WaitGroup, msgType string, raw []byte) (bool, error) {
+func (c *CLI) handleCommandPluginMessage(cmd *cobra.Command, requestCtx context.Context, writer *commandPluginWriter, requestWG *sync.WaitGroup, progress *commandProgressRenderer, msgType string, raw []byte) (bool, error) {
 	if len(raw) > maxCommandPluginInboundMessageBytes {
 		return false, fmt.Errorf("command plugin: message %s exceeded %d bytes", msgType, maxCommandPluginInboundMessageBytes)
 	}
@@ -127,6 +127,15 @@ func (c *CLI) handleCommandPluginMessage(cmd *cobra.Command, requestCtx context.
 		var msg pluginwire.ProgressMsg
 		if err := decodeCommandPluginMessage(msgType, raw, &msg); err != nil {
 			return false, err
+		}
+		if progress != nil && (msg.ID != "" || msg.Label != "") {
+			handled, err := progress.Write(msg)
+			if err != nil {
+				writeDiagnostic(cmd.ErrOrStderr(), diagnosticWarn, "warning", "progress formatter unavailable: %v", err)
+			}
+			if handled {
+				break
+			}
 		}
 		if msg.Text != "" {
 			fmt.Fprintln(cmd.ErrOrStderr(), msg.Text)

--- a/internal/cli/command_plugin_internal_test.go
+++ b/internal/cli/command_plugin_internal_test.go
@@ -36,7 +36,7 @@ func TestHandleCommandPluginMessageRejectsMalformedDone(t *testing.T) {
 		t.Fatalf("marshal: %v", err)
 	}
 
-	done, gotErr := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, "done", raw)
+	done, gotErr := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, nil, "done", raw)
 	if !done {
 		t.Fatal("expected malformed done message to stop processing")
 	}
@@ -63,7 +63,7 @@ func TestHandleCommandPluginMessageRejectsOversizedStdoutData(t *testing.T) {
 		t.Fatalf("marshal: %v", err)
 	}
 
-	done, gotErr := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, pluginwire.MsgTypeStdoutData, raw)
+	done, gotErr := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, nil, pluginwire.MsgTypeStdoutData, raw)
 	if done {
 		t.Fatal("stdout-data should not mark command plugin done")
 	}
@@ -93,7 +93,7 @@ func TestHandleCommandPluginMessageRejectsOversizedStderrData(t *testing.T) {
 		t.Fatalf("marshal: %v", err)
 	}
 
-	done, gotErr := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, pluginwire.MsgTypeStderrData, raw)
+	done, gotErr := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, nil, pluginwire.MsgTypeStderrData, raw)
 	if done {
 		t.Fatal("stderr-data should not mark command plugin done")
 	}

--- a/internal/cli/command_plugin_progress.go
+++ b/internal/cli/command_plugin_progress.go
@@ -1,0 +1,154 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/rest-sh/restish/v2/internal/output"
+	pluginwire "github.com/rest-sh/restish/v2/plugin"
+	"github.com/spf13/cobra"
+)
+
+type commandProgressRenderer struct {
+	formatter  output.ValueStreamFormatter
+	stream     output.ValueStream
+	cmd        *cobra.Command
+	ctx        context.Context
+	cancel     context.CancelFunc
+	subprocess bool
+	disabled   bool
+	fallback   []string
+	bytes      int
+}
+
+func (c *CLI) newCommandProgressRenderer(cmd *cobra.Command) *commandProgressRenderer {
+	formatter, ok := c.formatters["progress"].(output.ValueStreamFormatter)
+	if !ok {
+		return nil
+	}
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	subprocess := false
+	if pluginFormatter, ok := formatter.(*output.PluginFormatter); ok {
+		clone := *pluginFormatter
+		clone.Context = ctx
+		formatter = &clone
+		subprocess = true
+	}
+	return &commandProgressRenderer{
+		formatter:  formatter,
+		cmd:        cmd,
+		ctx:        ctx,
+		cancel:     cancel,
+		subprocess: subprocess,
+	}
+}
+
+func (r *commandProgressRenderer) Write(msg pluginwire.ProgressMsg) (bool, error) {
+	if r.disabled {
+		return false, nil
+	}
+	if (msg.Current == nil) != (msg.Total == nil) || msg.Current != nil && (*msg.Current < 0 || *msg.Total <= 0 || *msg.Current > *msg.Total) {
+		return false, nil
+	}
+	if msg.Text != "" && r.bytes+len(msg.Text)+1 > maxCommandPluginDataBytes {
+		err := r.closeStream()
+		r.disabled = true
+		return false, err
+	}
+	if r.stream == nil {
+		// Command stderr is not coordinated with formatter redraws yet, so keep
+		// this session line-oriented even when stderr is a terminal.
+		stream, err := r.formatter.StartValueStream(r.cmd.ErrOrStderr(), &output.Response{}, false)
+		if err != nil {
+			r.disabled = true
+			return false, err
+		}
+		r.stream = stream
+	}
+	record := map[string]any{
+		"id":      msg.ID,
+		"label":   msg.Label,
+		"state":   msg.State,
+		"current": msg.Current,
+		"total":   msg.Total,
+		"message": msg.Message,
+	}
+	stream := r.stream
+	if err := r.run(func() error { return stream.WriteValue(record) }); err != nil {
+		var closeErr error
+		if r.ctx.Err() != nil {
+			if r.subprocess {
+				closeErr = stream.Close()
+			}
+			r.stream = nil
+			r.replayFallback()
+		} else {
+			closeErr = r.closeStream()
+		}
+		r.disabled = true
+		return false, errors.Join(err, closeErr)
+	}
+	if msg.Text != "" {
+		r.fallback = append(r.fallback, msg.Text)
+		r.bytes += len(msg.Text) + 1
+	}
+	return true, nil
+}
+
+func (r *commandProgressRenderer) Close() error {
+	defer r.cancel()
+	return r.closeStream()
+}
+
+func (r *commandProgressRenderer) closeStream() error {
+	if r.stream == nil {
+		return nil
+	}
+	err := r.run(r.stream.Close)
+	r.stream = nil
+	if err != nil {
+		r.replayFallback()
+	} else {
+		r.fallback = nil
+		r.bytes = 0
+	}
+	return err
+}
+
+func (r *commandProgressRenderer) replayFallback() {
+	for _, text := range r.fallback {
+		fmt.Fprintln(r.cmd.ErrOrStderr(), text)
+	}
+	r.fallback = nil
+	r.bytes = 0
+}
+
+func (r *commandProgressRenderer) run(fn func() error) error {
+	done := make(chan error, 1)
+	go func() { done <- fn() }()
+	timeout := commandPluginShutdownGrace()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case err := <-done:
+		return err
+	case <-r.ctx.Done():
+		r.cancel()
+		if r.subprocess {
+			return errors.Join(r.ctx.Err(), <-done)
+		}
+		return r.ctx.Err()
+	case <-timer.C:
+		r.cancel()
+		if r.subprocess {
+			return errors.Join(fmt.Errorf("timed out after %s", timeout), <-done)
+		}
+		return fmt.Errorf("timed out after %s", timeout)
+	}
+}

--- a/internal/cli/command_plugin_progress.go
+++ b/internal/cli/command_plugin_progress.go
@@ -77,6 +77,7 @@ func (r *commandProgressRenderer) Write(msg pluginwire.ProgressMsg) (bool, error
 		"state":   msg.State,
 		"current": msg.Current,
 		"total":   msg.Total,
+		"unit":    msg.Unit,
 		"message": msg.Message,
 	}
 	stream := r.stream

--- a/internal/cli/command_plugin_progress.go
+++ b/internal/cli/command_plugin_progress.go
@@ -1,10 +1,7 @@
 package cli
 
 import (
-	"context"
-	"errors"
 	"fmt"
-	"time"
 
 	"github.com/rest-sh/restish/v2/internal/output"
 	pluginwire "github.com/rest-sh/restish/v2/plugin"
@@ -12,41 +9,19 @@ import (
 )
 
 type commandProgressRenderer struct {
-	formatter  output.ValueStreamFormatter
-	stream     output.ValueStream
-	cmd        *cobra.Command
-	ctx        context.Context
-	cancel     context.CancelFunc
-	subprocess bool
-	disabled   bool
-	fallback   []string
-	bytes      int
+	session  *progressFormatterSession
+	cmd      *cobra.Command
+	disabled bool
+	fallback []string
+	bytes    int
 }
 
 func (c *CLI) newCommandProgressRenderer(cmd *cobra.Command) *commandProgressRenderer {
-	formatter, ok := c.formatters["progress"].(output.ValueStreamFormatter)
-	if !ok {
+	session := c.newProgressFormatterSession(cmd.Context(), commandPluginShutdownGrace())
+	if session == nil {
 		return nil
 	}
-	ctx := cmd.Context()
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	ctx, cancel := context.WithCancel(ctx)
-	subprocess := false
-	if pluginFormatter, ok := formatter.(*output.PluginFormatter); ok {
-		clone := *pluginFormatter
-		clone.Context = ctx
-		formatter = &clone
-		subprocess = true
-	}
-	return &commandProgressRenderer{
-		formatter:  formatter,
-		cmd:        cmd,
-		ctx:        ctx,
-		cancel:     cancel,
-		subprocess: subprocess,
-	}
+	return &commandProgressRenderer{session: session, cmd: cmd}
 }
 
 func (r *commandProgressRenderer) Write(msg pluginwire.ProgressMsg) (bool, error) {
@@ -57,19 +32,9 @@ func (r *commandProgressRenderer) Write(msg pluginwire.ProgressMsg) (bool, error
 		return false, nil
 	}
 	if msg.Text != "" && r.bytes+len(msg.Text)+1 > maxCommandPluginDataBytes {
-		err := r.closeStream()
+		err := r.Close()
 		r.disabled = true
 		return false, err
-	}
-	if r.stream == nil {
-		// Command stderr is not coordinated with formatter redraws yet, so keep
-		// this session line-oriented even when stderr is a terminal.
-		stream, err := r.formatter.StartValueStream(r.cmd.ErrOrStderr(), &output.Response{}, false)
-		if err != nil {
-			r.disabled = true
-			return false, err
-		}
-		r.stream = stream
 	}
 	record := map[string]any{
 		"id":      msg.ID,
@@ -80,20 +45,12 @@ func (r *commandProgressRenderer) Write(msg pluginwire.ProgressMsg) (bool, error
 		"unit":    msg.Unit,
 		"message": msg.Message,
 	}
-	stream := r.stream
-	if err := r.run(func() error { return stream.WriteValue(record) }); err != nil {
-		var closeErr error
-		if r.ctx.Err() != nil {
-			if r.subprocess {
-				closeErr = stream.Close()
-			}
-			r.stream = nil
-			r.replayFallback()
-		} else {
-			closeErr = r.closeStream()
-		}
+	// Command stderr is not coordinated with formatter redraws yet, so keep
+	// this session line-oriented even when stderr is a terminal.
+	if err := r.session.Write(r.cmd.ErrOrStderr(), &output.Response{}, false, record); err != nil {
+		r.replayFallback()
 		r.disabled = true
-		return false, errors.Join(err, closeErr)
+		return false, err
 	}
 	if msg.Text != "" {
 		r.fallback = append(r.fallback, msg.Text)
@@ -103,16 +60,7 @@ func (r *commandProgressRenderer) Write(msg pluginwire.ProgressMsg) (bool, error
 }
 
 func (r *commandProgressRenderer) Close() error {
-	defer r.cancel()
-	return r.closeStream()
-}
-
-func (r *commandProgressRenderer) closeStream() error {
-	if r.stream == nil {
-		return nil
-	}
-	err := r.run(r.stream.Close)
-	r.stream = nil
+	err := r.session.Close()
 	if err != nil {
 		r.replayFallback()
 	} else {
@@ -128,28 +76,4 @@ func (r *commandProgressRenderer) replayFallback() {
 	}
 	r.fallback = nil
 	r.bytes = 0
-}
-
-func (r *commandProgressRenderer) run(fn func() error) error {
-	done := make(chan error, 1)
-	go func() { done <- fn() }()
-	timeout := commandPluginShutdownGrace()
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
-	select {
-	case err := <-done:
-		return err
-	case <-r.ctx.Done():
-		r.cancel()
-		if r.subprocess {
-			return errors.Join(r.ctx.Err(), <-done)
-		}
-		return r.ctx.Err()
-	case <-timer.C:
-		r.cancel()
-		if r.subprocess {
-			return errors.Join(fmt.Errorf("timed out after %s", timeout), <-done)
-		}
-		return fmt.Errorf("timed out after %s", timeout)
-	}
 }

--- a/internal/cli/command_plugin_progress_test.go
+++ b/internal/cli/command_plugin_progress_test.go
@@ -1,0 +1,209 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/rest-sh/restish/v2/internal/output"
+	pluginwire "github.com/rest-sh/restish/v2/plugin"
+	"github.com/spf13/cobra"
+)
+
+type recordingProgressFormatter struct {
+	startErr error
+	starts   int
+	color    bool
+	stream   recordingProgressStream
+}
+
+func (f *recordingProgressFormatter) Format(io.Writer, *output.Response, bool) error {
+	return nil
+}
+
+func (f *recordingProgressFormatter) StartValueStream(_ io.Writer, _ *output.Response, color bool) (output.ValueStream, error) {
+	f.starts++
+	f.color = color
+	if f.startErr != nil {
+		return nil, f.startErr
+	}
+	return &f.stream, nil
+}
+
+type recordingProgressStream struct {
+	values     []any
+	closed     bool
+	closeErr   error
+	writeBlock <-chan struct{}
+	writeDone  chan<- struct{}
+}
+
+func (s *recordingProgressStream) WriteValue(value any) error {
+	if s.writeDone != nil {
+		defer close(s.writeDone)
+	}
+	if s.writeBlock != nil {
+		<-s.writeBlock
+	}
+	s.values = append(s.values, value)
+	return nil
+}
+
+func (s *recordingProgressStream) Close() error {
+	s.closed = true
+	return s.closeErr
+}
+
+func TestStructuredCommandProgressUsesOneFormatterSession(t *testing.T) {
+	var stderr bytes.Buffer
+	formatter := &recordingProgressFormatter{}
+	cli := &CLI{Stderr: &stderr, formatters: map[string]output.Formatter{"progress": formatter}}
+	cmd := &cobra.Command{Use: "test"}
+	cmd.SetErr(&stderr)
+	renderer := cli.newCommandProgressRenderer(cmd)
+
+	for current := int64(1); current <= 2; current++ {
+		total := int64(2)
+		msg := pluginwire.ProgressMsg{Type: pluginwire.MsgTypeProgress, Text: "fallback", ID: "workflow", State: "running", Current: &current, Total: &total}
+		raw, err := cbor.Marshal(msg)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if _, err := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, renderer, pluginwire.MsgTypeProgress, raw); err != nil {
+			t.Fatalf("handleCommandPluginMessage: %v", err)
+		}
+	}
+	if err := renderer.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if formatter.starts != 1 || formatter.color || len(formatter.stream.values) != 2 || !formatter.stream.closed {
+		t.Fatalf("formatter starts=%d color=%t values=%d closed=%t", formatter.starts, formatter.color, len(formatter.stream.values), formatter.stream.closed)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("fallback written despite formatter: %q", stderr.String())
+	}
+}
+
+func TestStructuredCommandProgressFallsBackWithoutFormatter(t *testing.T) {
+	var stderr bytes.Buffer
+	cli := &CLI{Stderr: &stderr}
+	cmd := &cobra.Command{Use: "test"}
+	cmd.SetErr(&stderr)
+	msg := pluginwire.ProgressMsg{Type: pluginwire.MsgTypeProgress, Text: "Running step 1 of 2", ID: "workflow"}
+	raw, err := cbor.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if _, err := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, cli.newCommandProgressRenderer(cmd), pluginwire.MsgTypeProgress, raw); err != nil {
+		t.Fatalf("handleCommandPluginMessage: %v", err)
+	}
+	if got := stderr.String(); got != "Running step 1 of 2\n" {
+		t.Fatalf("stderr = %q", got)
+	}
+}
+
+func TestInvalidStructuredCommandProgressFallsBack(t *testing.T) {
+	var stderr bytes.Buffer
+	formatter := &recordingProgressFormatter{}
+	cli := &CLI{Stderr: &stderr, formatters: map[string]output.Formatter{"progress": formatter}}
+	cmd := &cobra.Command{Use: "test"}
+	cmd.SetErr(&stderr)
+	renderer := cli.newCommandProgressRenderer(cmd)
+	current := int64(1)
+	msg := pluginwire.ProgressMsg{Type: pluginwire.MsgTypeProgress, Text: "fallback", ID: "workflow", Current: &current}
+	raw, err := cbor.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if _, err := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, renderer, pluginwire.MsgTypeProgress, raw); err != nil {
+		t.Fatalf("handleCommandPluginMessage: %v", err)
+	}
+	if formatter.starts != 0 || stderr.String() != "fallback\n" {
+		t.Fatalf("formatter starts=%d stderr=%q", formatter.starts, stderr.String())
+	}
+}
+
+func TestStructuredCommandProgressFallsBackAfterFormatterFailure(t *testing.T) {
+	var stderr bytes.Buffer
+	formatter := &recordingProgressFormatter{startErr: errors.New("boom")}
+	cli := &CLI{Stderr: &stderr, formatters: map[string]output.Formatter{"progress": formatter}}
+	cmd := &cobra.Command{Use: "test"}
+	cmd.SetErr(&stderr)
+	renderer := cli.newCommandProgressRenderer(cmd)
+	msg := pluginwire.ProgressMsg{Type: pluginwire.MsgTypeProgress, Text: "fallback", ID: "workflow"}
+	raw, err := cbor.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	for range 2 {
+		if _, err := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, renderer, pluginwire.MsgTypeProgress, raw); err != nil {
+			t.Fatalf("handleCommandPluginMessage: %v", err)
+		}
+	}
+	if formatter.starts != 1 {
+		t.Fatalf("formatter starts = %d, want 1", formatter.starts)
+	}
+	if got := stderr.String(); strings.Count(got, "progress formatter unavailable") != 1 || strings.Count(got, "fallback\n") != 2 {
+		t.Fatalf("stderr = %q", got)
+	}
+}
+
+func TestStructuredCommandProgressReplaysFallbackAfterCloseFailure(t *testing.T) {
+	var stderr bytes.Buffer
+	formatter := &recordingProgressFormatter{}
+	formatter.stream.closeErr = errors.New("boom")
+	cli := &CLI{Stderr: &stderr, formatters: map[string]output.Formatter{"progress": formatter}}
+	cmd := &cobra.Command{Use: "test"}
+	cmd.SetErr(&stderr)
+	renderer := cli.newCommandProgressRenderer(cmd)
+	msg := pluginwire.ProgressMsg{Type: pluginwire.MsgTypeProgress, Text: "fallback", ID: "workflow"}
+	raw, err := cbor.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if _, err := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, renderer, pluginwire.MsgTypeProgress, raw); err != nil {
+		t.Fatalf("handleCommandPluginMessage: %v", err)
+	}
+	if err := renderer.Close(); err == nil {
+		t.Fatal("Close returned nil")
+	}
+	if got := stderr.String(); got != "fallback\n" {
+		t.Fatalf("stderr = %q", got)
+	}
+}
+
+func TestStructuredCommandProgressBoundsBlockedFormatter(t *testing.T) {
+	t.Setenv("RSH_COMMAND_PLUGIN_SHUTDOWN_GRACE", "20ms")
+	var stderr bytes.Buffer
+	block := make(chan struct{})
+	done := make(chan struct{})
+	formatter := &recordingProgressFormatter{}
+	formatter.stream.writeBlock = block
+	formatter.stream.writeDone = done
+	cli := &CLI{Stderr: &stderr, formatters: map[string]output.Formatter{"progress": formatter}}
+	cmd := &cobra.Command{Use: "test"}
+	cmd.SetErr(&stderr)
+	renderer := cli.newCommandProgressRenderer(cmd)
+	msg := pluginwire.ProgressMsg{Type: pluginwire.MsgTypeProgress, Text: "fallback", ID: "workflow"}
+	raw, err := cbor.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if _, err := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, renderer, pluginwire.MsgTypeProgress, raw); err != nil {
+		t.Fatalf("handleCommandPluginMessage: %v", err)
+	}
+	close(block)
+	<-done
+	if got := stderr.String(); !strings.Contains(got, "timed out after 20ms") || !strings.Contains(got, "fallback\n") {
+		t.Fatalf("stderr = %q", got)
+	}
+}

--- a/internal/cli/command_plugin_progress_test.go
+++ b/internal/cli/command_plugin_progress_test.go
@@ -35,20 +35,12 @@ func (f *recordingProgressFormatter) StartValueStream(_ io.Writer, _ *output.Res
 }
 
 type recordingProgressStream struct {
-	values     []any
-	closed     bool
-	closeErr   error
-	writeBlock <-chan struct{}
-	writeDone  chan<- struct{}
+	values   []any
+	closed   bool
+	closeErr error
 }
 
 func (s *recordingProgressStream) WriteValue(value any) error {
-	if s.writeDone != nil {
-		defer close(s.writeDone)
-	}
-	if s.writeBlock != nil {
-		<-s.writeBlock
-	}
 	s.values = append(s.values, value)
 	return nil
 }
@@ -176,34 +168,6 @@ func TestStructuredCommandProgressReplaysFallbackAfterCloseFailure(t *testing.T)
 		t.Fatal("Close returned nil")
 	}
 	if got := stderr.String(); got != "fallback\n" {
-		t.Fatalf("stderr = %q", got)
-	}
-}
-
-func TestStructuredCommandProgressBoundsBlockedFormatter(t *testing.T) {
-	t.Setenv("RSH_COMMAND_PLUGIN_SHUTDOWN_GRACE", "20ms")
-	var stderr bytes.Buffer
-	block := make(chan struct{})
-	done := make(chan struct{})
-	formatter := &recordingProgressFormatter{}
-	formatter.stream.writeBlock = block
-	formatter.stream.writeDone = done
-	cli := &CLI{Stderr: &stderr, formatters: map[string]output.Formatter{"progress": formatter}}
-	cmd := &cobra.Command{Use: "test"}
-	cmd.SetErr(&stderr)
-	renderer := cli.newCommandProgressRenderer(cmd)
-	msg := pluginwire.ProgressMsg{Type: pluginwire.MsgTypeProgress, Text: "fallback", ID: "workflow"}
-	raw, err := cbor.Marshal(msg)
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
-
-	if _, err := cli.handleCommandPluginMessage(cmd, context.Background(), nil, nil, renderer, pluginwire.MsgTypeProgress, raw); err != nil {
-		t.Fatalf("handleCommandPluginMessage: %v", err)
-	}
-	close(block)
-	<-done
-	if got := stderr.String(); !strings.Contains(got, "timed out after 20ms") || !strings.Contains(got, "fallback\n") {
 		t.Fatalf("stderr = %q", got)
 	}
 }

--- a/internal/cli/command_plugin_runtime.go
+++ b/internal/cli/command_plugin_runtime.go
@@ -194,6 +194,7 @@ func (c *CLI) runCommandPlugin(cmd *cobra.Command, pluginPath string, decl plugi
 	requestCtx, cancelRequests := context.WithCancel(cmd.Context())
 	defer cancelRequests()
 	dec := pluginwire.NewDecoder(stdoutPipe)
+	progress := c.newCommandProgressRenderer(cmd)
 	for {
 		raw, err := dec.ReadRaw()
 		if err != nil {
@@ -211,7 +212,7 @@ func (c *CLI) runCommandPlugin(cmd *cobra.Command, pluginPath string, decl plugi
 			break
 		}
 
-		done, err := c.handleCommandPluginMessage(cmd, requestCtx, writer, &requestWG, pluginwire.MessageType(raw), raw)
+		done, err := c.handleCommandPluginMessage(cmd, requestCtx, writer, &requestWG, progress, pluginwire.MessageType(raw), raw)
 		if err != nil {
 			loopErr = err
 			break
@@ -225,6 +226,11 @@ func (c *CLI) runCommandPlugin(cmd *cobra.Command, pluginPath string, decl plugi
 	close(cancelWatchDone)
 	close(stopCh)
 	cancelRequests()
+	if progress != nil {
+		if err := progress.Close(); err != nil {
+			writeDiagnostic(cmd.ErrOrStderr(), diagnosticWarn, "warning", "progress formatter cleanup failed: %v", err)
+		}
+	}
 	stderrWriter.Flush()
 	if loopErr != nil {
 		_ = stdinPipe.Close()

--- a/internal/cli/download_progress.go
+++ b/internal/cli/download_progress.go
@@ -1,0 +1,128 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/rest-sh/restish/v2/internal/output"
+)
+
+const downloadProgressInterval = 100 * time.Millisecond
+
+type downloadProgress struct {
+	session  *progressFormatterSession
+	ctx      context.Context
+	stderr   io.Writer
+	base     *output.Response
+	total    int64
+	current  int64
+	last     time.Time
+	now      func() time.Time
+	color    bool
+	disabled bool
+	warned   bool
+}
+
+func (c *CLI) newDownloadProgress(ctx context.Context, resp *http.Response) *downloadProgress {
+	if !c.stderrIsTerminal() || resp == nil || resp.Body == nil || resp.ContentLength == 0 || output.ResponseHasNoBody(resp) {
+		return nil
+	}
+	session := c.newProgressFormatterSession(ctx, defaultProgressFormatterTimeout)
+	if session == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	p := &downloadProgress{
+		session: session,
+		ctx:     ctx,
+		stderr:  c.Stderr,
+		base:    responseMetadataOnly(resp),
+		total:   resp.ContentLength,
+		now:     time.Now,
+		color:   output.ColorEnabled(c.Stderr),
+	}
+	p.last = p.now()
+	if err := p.write("running"); err != nil {
+		p.warn(err)
+		_ = p.session.Close()
+		return nil
+	}
+	return p
+}
+
+func (p *downloadProgress) observe(n int) {
+	if p == nil || p.disabled || n <= 0 {
+		return
+	}
+	p.current += int64(n)
+	if p.total > 0 && p.current >= p.total {
+		return
+	}
+	now := p.now()
+	if now.Sub(p.last) < downloadProgressInterval {
+		return
+	}
+	p.last = now
+	if err := p.write("running"); err != nil {
+		p.warn(err)
+		p.disabled = true
+		_ = p.session.Close()
+	}
+}
+
+func (p *downloadProgress) finish(readErr error) {
+	if p == nil || p.disabled {
+		return
+	}
+	state := "success"
+	if readErr != nil {
+		state = "failed"
+	}
+	if err := p.write(state); err != nil {
+		p.warn(err)
+	}
+	if err := p.session.Close(); err != nil {
+		p.warn(err)
+	}
+	p.disabled = true
+}
+
+func (p *downloadProgress) write(state string) error {
+	record := map[string]any{
+		"id":    "http-download",
+		"label": "Download",
+		"state": state,
+		"unit":  "bytes",
+	}
+	if p.total > 0 {
+		record["current"] = p.current
+		record["total"] = p.total
+	} else {
+		record["message"] = fmt.Sprintf("%d bytes", p.current)
+	}
+	return p.session.Write(p.stderr, p.base, p.color, record)
+}
+
+func (p *downloadProgress) warn(err error) {
+	if p.warned || p.ctx.Err() != nil {
+		return
+	}
+	p.warned = true
+	writeDiagnostic(p.stderr, diagnosticWarn, "warning", "download progress unavailable: %v", err)
+}
+
+type downloadProgressReader struct {
+	reader   io.Reader
+	progress *downloadProgress
+}
+
+func (r downloadProgressReader) Read(buf []byte) (int, error) {
+	n, err := r.reader.Read(buf)
+	r.progress.observe(n)
+	return n, err
+}

--- a/internal/cli/download_progress_test.go
+++ b/internal/cli/download_progress_test.go
@@ -1,0 +1,196 @@
+package cli
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/rest-sh/restish/v2/internal/content"
+	"github.com/rest-sh/restish/v2/internal/output"
+)
+
+func TestRawDownloadReportsKnownLengthWithoutChangingBody(t *testing.T) {
+	body := []byte("download body")
+	formatter := &recordingProgressFormatter{}
+	cli, stderr := downloadProgressTestCLI(formatter, true)
+	resp := &http.Response{StatusCode: 200, Proto: "HTTP/1.1", ContentLength: int64(len(body)), Body: io.NopCloser(bytes.NewReader(body)), Header: http.Header{}}
+
+	progress := cli.newDownloadProgress(t.Context(), resp)
+	raw, err := cli.rawResponseBodyBytes(resp, 1024, progress)
+	progress.finish(err)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(raw, body) {
+		t.Fatalf("raw body = %q", raw)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+	if formatter.starts != 1 || len(formatter.stream.values) != 2 || !formatter.stream.closed {
+		t.Fatalf("formatter starts=%d values=%d closed=%t", formatter.starts, len(formatter.stream.values), formatter.stream.closed)
+	}
+	initial := formatter.stream.values[0].(map[string]any)
+	final := formatter.stream.values[1].(map[string]any)
+	if initial["current"] != int64(0) || initial["total"] != int64(len(body)) || initial["unit"] != "bytes" || initial["state"] != "running" {
+		t.Fatalf("initial record = %#v", initial)
+	}
+	if final["current"] != int64(len(body)) || final["total"] != int64(len(body)) || final["state"] != "success" {
+		t.Fatalf("final record = %#v", final)
+	}
+}
+
+func TestRawDownloadCountsCompressedWireBytes(t *testing.T) {
+	var compressed bytes.Buffer
+	zw := gzip.NewWriter(&compressed)
+	if _, err := zw.Write(bytes.Repeat([]byte("content"), 100)); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	formatter := &recordingProgressFormatter{}
+	cli, _ := downloadProgressTestCLI(formatter, true)
+	resp := &http.Response{
+		StatusCode:    200,
+		ContentLength: int64(compressed.Len()),
+		Body:          io.NopCloser(bytes.NewReader(compressed.Bytes())),
+		Header:        http.Header{"Content-Encoding": {"gzip"}},
+	}
+
+	progress := cli.newDownloadProgress(t.Context(), resp)
+	raw, err := cli.rawResponseBodyBytes(resp, 2048, progress)
+	progress.finish(err)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(raw) != 700 {
+		t.Fatalf("decompressed length = %d", len(raw))
+	}
+	final := formatter.stream.values[len(formatter.stream.values)-1].(map[string]any)
+	if final["current"] != int64(compressed.Len()) || final["total"] != int64(compressed.Len()) {
+		t.Fatalf("final record = %#v, compressed bytes = %d", final, compressed.Len())
+	}
+}
+
+func TestRawDownloadReportsUnknownLength(t *testing.T) {
+	formatter := &recordingProgressFormatter{}
+	cli, _ := downloadProgressTestCLI(formatter, true)
+	resp := &http.Response{StatusCode: 200, ContentLength: -1, Body: io.NopCloser(bytes.NewReader([]byte("body"))), Header: http.Header{}}
+
+	progress := cli.newDownloadProgress(t.Context(), resp)
+	_, err := cli.rawResponseBodyBytes(resp, 1024, progress)
+	progress.finish(err)
+	if err != nil {
+		t.Fatal(err)
+	}
+	final := formatter.stream.values[len(formatter.stream.values)-1].(map[string]any)
+	if _, ok := final["total"]; ok || final["message"] != "4 bytes" || final["state"] != "success" {
+		t.Fatalf("final record = %#v", final)
+	}
+}
+
+func TestRawDownloadThrottlesUpdates(t *testing.T) {
+	formatter := &recordingProgressFormatter{}
+	cli, _ := downloadProgressTestCLI(formatter, true)
+	resp := &http.Response{StatusCode: 200, ContentLength: 4, Body: io.NopCloser(bytes.NewReader(nil)), Header: http.Header{}}
+	progress := cli.newDownloadProgress(t.Context(), resp)
+	now := time.Unix(0, 0)
+	progress.now = func() time.Time { return now }
+	progress.last = now
+
+	progress.observe(1)
+	now = now.Add(50 * time.Millisecond)
+	progress.observe(1)
+	now = now.Add(50 * time.Millisecond)
+	progress.observe(1)
+	progress.observe(1)
+	progress.finish(nil)
+
+	if len(formatter.stream.values) != 3 {
+		t.Fatalf("records = %d, want initial, throttled update, final", len(formatter.stream.values))
+	}
+	update := formatter.stream.values[1].(map[string]any)
+	if update["current"] != int64(3) || update["state"] != "running" {
+		t.Fatalf("update = %#v", update)
+	}
+}
+
+func TestRawDownloadFailureClosesProgress(t *testing.T) {
+	formatter := &recordingProgressFormatter{}
+	cli, _ := downloadProgressTestCLI(formatter, true)
+	resp := &http.Response{StatusCode: 200, ContentLength: 4, Body: io.NopCloser(io.MultiReader(bytes.NewReader([]byte("body")), errorReader{})), Header: http.Header{}}
+
+	progress := cli.newDownloadProgress(t.Context(), resp)
+	_, err := cli.rawResponseBodyBytes(resp, 1024, progress)
+	progress.finish(err)
+	if err == nil {
+		t.Fatal("rawResponseBodyBytes returned nil error")
+	}
+	final := formatter.stream.values[len(formatter.stream.values)-1].(map[string]any)
+	if final["state"] != "failed" || !formatter.stream.closed {
+		t.Fatalf("final record = %#v, closed=%t", final, formatter.stream.closed)
+	}
+}
+
+func TestRawDownloadProgressRequiresTTYAndFormatter(t *testing.T) {
+	formatter := &recordingProgressFormatter{}
+	cli, _ := downloadProgressTestCLI(formatter, false)
+	resp := &http.Response{StatusCode: 200, ContentLength: 4, Body: io.NopCloser(bytes.NewReader([]byte("body"))), Header: http.Header{}}
+	if progress := cli.newDownloadProgress(t.Context(), resp); progress != nil || formatter.starts != 0 {
+		t.Fatalf("progress = %#v, formatter starts = %d", progress, formatter.starts)
+	}
+
+	cli.formatters = output.DefaultFormatters()
+	cli.hooks.StderrIsTerminal = func(io.Writer) bool { return true }
+	if progress := cli.newDownloadProgress(t.Context(), resp); progress != nil {
+		t.Fatalf("progress without formatter = %#v", progress)
+	}
+}
+
+func TestRawDownloadFormatterFailureIsAdvisory(t *testing.T) {
+	formatter := &recordingProgressFormatter{startErr: errors.New("boom")}
+	cli, stderr := downloadProgressTestCLI(formatter, true)
+	resp := &http.Response{StatusCode: 200, ContentLength: 4, Body: io.NopCloser(bytes.NewReader([]byte("body"))), Header: http.Header{}}
+	if progress := cli.newDownloadProgress(t.Context(), resp); progress != nil {
+		t.Fatalf("progress = %#v", progress)
+	}
+	if got := stderr.String(); got == "" || !bytes.Contains(stderr.Bytes(), []byte("download progress unavailable")) {
+		t.Fatalf("stderr = %q", got)
+	}
+}
+
+func TestRawDownloadCancellationSuppressesFormatterWarning(t *testing.T) {
+	formatter := &recordingProgressFormatter{}
+	formatter.stream.closeErr = errors.New("killed")
+	cli, stderr := downloadProgressTestCLI(formatter, true)
+	resp := &http.Response{StatusCode: 200, ContentLength: 4, Body: io.NopCloser(bytes.NewReader([]byte("body"))), Header: http.Header{}}
+	ctx, cancel := context.WithCancel(context.Background())
+	progress := cli.newDownloadProgress(ctx, resp)
+	cancel()
+	progress.finish(context.Canceled)
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func downloadProgressTestCLI(formatter output.Formatter, tty bool) (*CLI, *bytes.Buffer) {
+	stderr := &bytes.Buffer{}
+	return &CLI{
+		Stderr:     stderr,
+		content:    content.Default(),
+		formatters: map[string]output.Formatter{"progress": formatter},
+		hooks:      testHooks{StderrIsTerminal: func(io.Writer) bool { return tty }},
+	}, stderr
+}
+
+type errorReader struct{}
+
+func (errorReader) Read([]byte) (int, error) {
+	return 0, errors.New("read failed")
+}

--- a/internal/cli/http.go
+++ b/internal/cli/http.go
@@ -346,8 +346,13 @@ func (c *CLI) runHTTPWithOptions(cmd *cobra.Command, method string, args []strin
 	}
 	if printSpec.rawBodyOnly() {
 		defer httpResp.Body.Close()
-		raw, err := c.rawResponseBodyBytes(httpResp, maxBodyBytes(cmd))
+		var progress *downloadProgress
+		if gf.Verbose == 0 {
+			progress = c.newDownloadProgress(requestContext(cmd), httpResp)
+		}
+		raw, err := c.rawResponseBodyBytes(httpResp, maxBodyBytes(cmd), progress)
 		if err != nil {
+			progress.finish(err)
 			return responseBodyReadError(method, rawURL, err)
 		}
 		if gf.Verbose >= 1 {
@@ -357,8 +362,10 @@ func (c *CLI) runHTTPWithOptions(cmd *cobra.Command, method string, args []strin
 		trace.Step("raw")
 		trace.RenderAfter(c.Stderr, gf.Verbose)
 		if err := c.writeRawBytes(raw); err != nil {
+			progress.finish(err)
 			return err
 		}
+		progress.finish(nil)
 		return c.statusError(cmd, httpResp.StatusCode)
 	}
 	if c.canPrintWithoutResponseBody(gf, printSpec) {
@@ -669,7 +676,7 @@ func (c *CLI) runPrintSpec(cmd *cobra.Command, resp *output.Response, prepared *
 	return nil
 }
 
-func (c *CLI) rawResponseBodyBytes(resp *http.Response, maxBytes int64) ([]byte, error) {
+func (c *CLI) rawResponseBodyBytes(resp *http.Response, maxBytes int64, progress *downloadProgress) ([]byte, error) {
 	if resp == nil || resp.Body == nil {
 		return nil, nil
 	}
@@ -679,7 +686,11 @@ func (c *CLI) rawResponseBodyBytes(resp *http.Response, maxBytes int64) ([]byte,
 	if maxBytes <= 0 {
 		maxBytes = output.DefaultMaxBodyBytes
 	}
-	reader, err := c.content.Decompress(resp.Header.Get("Content-Encoding"), resp.Body)
+	body := io.Reader(resp.Body)
+	if progress != nil {
+		body = downloadProgressReader{reader: body, progress: progress}
+	}
+	reader, err := c.content.Decompress(resp.Header.Get("Content-Encoding"), body)
 	if err != nil {
 		return nil, fmt.Errorf("decompressing response: %w", err)
 	}

--- a/internal/cli/progress_formatter.go
+++ b/internal/cli/progress_formatter.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/rest-sh/restish/v2/internal/output"
+)
+
+const defaultProgressFormatterTimeout = 5 * time.Second
+
+type progressFormatterSession struct {
+	formatter  output.ValueStreamFormatter
+	stream     output.ValueStream
+	ctx        context.Context
+	cancel     context.CancelFunc
+	subprocess bool
+	timeout    time.Duration
+}
+
+func (c *CLI) newProgressFormatterSession(ctx context.Context, timeout time.Duration) *progressFormatterSession {
+	formatter, ok := c.formatters["progress"].(output.ValueStreamFormatter)
+	if !ok {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	subprocess := false
+	if pluginFormatter, ok := formatter.(*output.PluginFormatter); ok {
+		clone := *pluginFormatter
+		clone.Context = ctx
+		formatter = &clone
+		subprocess = true
+	}
+	if timeout <= 0 {
+		timeout = defaultProgressFormatterTimeout
+	}
+	return &progressFormatterSession{formatter: formatter, ctx: ctx, cancel: cancel, subprocess: subprocess, timeout: timeout}
+}
+
+func (s *progressFormatterSession) Write(w io.Writer, base *output.Response, color bool, value any) error {
+	if s.stream == nil {
+		var stream output.ValueStream
+		err := s.run(func() error {
+			var err error
+			stream, err = s.formatter.StartValueStream(w, base, color)
+			return err
+		})
+		if err != nil {
+			if stream != nil {
+				return errors.Join(err, stream.Close())
+			}
+			return err
+		}
+		s.stream = stream
+	}
+	stream := s.stream
+	if err := s.run(func() error { return stream.WriteValue(value) }); err != nil {
+		var closeErr error
+		if s.ctx.Err() != nil {
+			if s.subprocess {
+				closeErr = stream.Close()
+			}
+			s.stream = nil
+		} else {
+			closeErr = s.closeStream()
+		}
+		return errors.Join(err, closeErr)
+	}
+	return nil
+}
+
+func (s *progressFormatterSession) Close() error {
+	defer s.cancel()
+	return s.closeStream()
+}
+
+func (s *progressFormatterSession) closeStream() error {
+	if s.stream == nil {
+		return nil
+	}
+	err := s.run(s.stream.Close)
+	s.stream = nil
+	return err
+}
+
+func (s *progressFormatterSession) run(fn func() error) error {
+	if !s.subprocess {
+		return fn()
+	}
+	done := make(chan error, 1)
+	go func() { done <- fn() }()
+	timer := time.NewTimer(s.timeout)
+	defer timer.Stop()
+	select {
+	case err := <-done:
+		return err
+	case <-s.ctx.Done():
+		s.cancel()
+		return errors.Join(s.ctx.Err(), <-done)
+	case <-timer.C:
+		s.cancel()
+		return errors.Join(fmt.Errorf("timed out after %s", s.timeout), <-done)
+	}
+}

--- a/internal/cli/progress_formatter_test.go
+++ b/internal/cli/progress_formatter_test.go
@@ -1,0 +1,38 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rest-sh/restish/v2/internal/output"
+)
+
+func TestProgressFormatterBoundsSubprocessStartup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script tests not supported on Windows")
+	}
+	path := filepath.Join(t.TempDir(), "restish-progress")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nsleep 30\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cli := &CLI{formatters: map[string]output.Formatter{
+		"progress": &output.PluginFormatter{PluginPath: path, FormatName: "progress"},
+	}}
+	session := cli.newProgressFormatterSession(context.Background(), 20*time.Millisecond)
+	base := &output.Response{Headers: map[string][]string{"X-Large": {strings.Repeat("x", 2<<20)}}}
+
+	start := time.Now()
+	err := session.Write(io.Discard, base, false, map[string]any{"label": "Download"})
+	if err == nil || !strings.Contains(err.Error(), "timed out after 20ms") {
+		t.Fatalf("Write error = %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("blocked formatter returned after %v", elapsed)
+	}
+}

--- a/plugin/client.go
+++ b/plugin/client.go
@@ -510,6 +510,12 @@ func (c *CommandClient) Progress(text string) error {
 	return c.WriteMessage(ProgressMsg{Type: MsgTypeProgress, Text: text})
 }
 
+// ProgressUpdate sends structured progress with Text as its plain fallback.
+func (c *CommandClient) ProgressUpdate(msg ProgressMsg) error {
+	msg.Type = MsgTypeProgress
+	return c.WriteMessage(msg)
+}
+
 // Done signals that the plugin has finished.  exitCode 0 means success; any
 // other value causes the host to exit with that code.
 func (c *CommandClient) Done(exitCode int) error {

--- a/plugin/client_test.go
+++ b/plugin/client_test.go
@@ -44,6 +44,7 @@ func TestCommandClientProgressUpdateWritesStructuredProgress(t *testing.T) {
 		State:   "running",
 		Current: &current,
 		Total:   &total,
+		Unit:    "steps",
 		Message: "fetch owner",
 	}); err != nil {
 		t.Fatalf("ProgressUpdate: %v", err)
@@ -53,7 +54,7 @@ func TestCommandClientProgressUpdateWritesStructuredProgress(t *testing.T) {
 	if err := NewDecoder(bytes.NewReader(out.Bytes())).ReadMessage(&msg); err != nil {
 		t.Fatalf("ReadMessage: %v", err)
 	}
-	if msg.Type != MsgTypeProgress || msg.Text != "Running step 2 of 4" || msg.ID != "workflow" || msg.Label != "Run workflow" || msg.State != "running" || msg.Current == nil || *msg.Current != 2 || msg.Total == nil || *msg.Total != 4 || msg.Message != "fetch owner" {
+	if msg.Type != MsgTypeProgress || msg.Text != "Running step 2 of 4" || msg.ID != "workflow" || msg.Label != "Run workflow" || msg.State != "running" || msg.Current == nil || *msg.Current != 2 || msg.Total == nil || *msg.Total != 4 || msg.Unit != "steps" || msg.Message != "fetch owner" {
 		t.Fatalf("message = %#v", msg)
 	}
 }

--- a/plugin/client_test.go
+++ b/plugin/client_test.go
@@ -33,6 +33,48 @@ func TestCommandClientProgressWritesProgressMessage(t *testing.T) {
 	}
 }
 
+func TestCommandClientProgressUpdateWritesStructuredProgress(t *testing.T) {
+	var out bytes.Buffer
+	client := NewCommandClient(bytes.NewReader(nil), &out)
+	current, total := int64(2), int64(4)
+	if err := client.ProgressUpdate(ProgressMsg{
+		Text:    "Running step 2 of 4",
+		ID:      "workflow",
+		Label:   "Run workflow",
+		State:   "running",
+		Current: &current,
+		Total:   &total,
+		Message: "fetch owner",
+	}); err != nil {
+		t.Fatalf("ProgressUpdate: %v", err)
+	}
+
+	var msg ProgressMsg
+	if err := NewDecoder(bytes.NewReader(out.Bytes())).ReadMessage(&msg); err != nil {
+		t.Fatalf("ReadMessage: %v", err)
+	}
+	if msg.Type != MsgTypeProgress || msg.Text != "Running step 2 of 4" || msg.ID != "workflow" || msg.Label != "Run workflow" || msg.State != "running" || msg.Current == nil || *msg.Current != 2 || msg.Total == nil || *msg.Total != 4 || msg.Message != "fetch owner" {
+		t.Fatalf("message = %#v", msg)
+	}
+}
+
+func TestStructuredProgressRetainsLegacyTextFallback(t *testing.T) {
+	var out bytes.Buffer
+	if err := WriteMessage(&out, ProgressMsg{Type: MsgTypeProgress, Text: "working", ID: "workflow"}); err != nil {
+		t.Fatalf("WriteMessage: %v", err)
+	}
+	var legacy struct {
+		Type string `cbor:"type"`
+		Text string `cbor:"text"`
+	}
+	if err := NewDecoder(bytes.NewReader(out.Bytes())).ReadMessage(&legacy); err != nil {
+		t.Fatalf("ReadMessage: %v", err)
+	}
+	if legacy.Type != MsgTypeProgress || legacy.Text != "working" {
+		t.Fatalf("legacy message = %#v", legacy)
+	}
+}
+
 func TestCommandClientWriteStdoutWritesStdoutDataMessage(t *testing.T) {
 	var out bytes.Buffer
 	client := NewCommandClient(bytes.NewReader(nil), &out)

--- a/plugin/doc.go
+++ b/plugin/doc.go
@@ -46,7 +46,7 @@
 //   - ListAPIsMsg / ListProfilesMsg for config discovery
 //   - ConfigReadMsg for effective API/profile/plugin config
 //   - PromptMsg / ConfirmMsg for user interaction
-//   - ResponseMsg, StdoutDataMsg, StderrDataMsg, WarnMsg, and DoneMsg for output
+//   - ResponseMsg, StdoutDataMsg, StderrDataMsg, WarnMsg, ProgressMsg, and DoneMsg for output
 //
 // For simple command plugins, plugin.Run and CommandClient are usually enough.
 //

--- a/plugin/messages.go
+++ b/plugin/messages.go
@@ -317,6 +317,7 @@ type ProgressMsg struct {
 	State   string `cbor:"state,omitempty"`
 	Current *int64 `cbor:"current,omitempty"`
 	Total   *int64 `cbor:"total,omitempty"`
+	Unit    string `cbor:"unit,omitempty"`
 	Message string `cbor:"message,omitempty"`
 }
 

--- a/plugin/messages.go
+++ b/plugin/messages.go
@@ -307,10 +307,17 @@ type WarnMsg struct {
 	Text string `cbor:"text"`
 }
 
-// ProgressMsg prints an informational progress line on the host stderr.
+// ProgressMsg reports command progress on the host stderr. Text is the plain
+// fallback when no structured progress formatter is available.
 type ProgressMsg struct {
-	Type string `cbor:"type"`
-	Text string `cbor:"text"`
+	Type    string `cbor:"type"`
+	Text    string `cbor:"text"`
+	ID      string `cbor:"id,omitempty"`
+	Label   string `cbor:"label,omitempty"`
+	State   string `cbor:"state,omitempty"`
+	Current *int64 `cbor:"current,omitempty"`
+	Total   *int64 `cbor:"total,omitempty"`
+	Message string `cbor:"message,omitempty"`
 }
 
 // SpinnerMsg requests spinner-style status text on the host stderr.

--- a/site/content/en/docs/guides/output.md
+++ b/site/content/en/docs/guides/output.md
@@ -129,6 +129,12 @@ without choosing a filter, metadata shortcut, collection, or explicit output
 format. Response middleware plugins are skipped on this raw-download path; they
 run when Restish renders, filters, collects, or prints an interpreted response.
 
+When stderr is a terminal and a streaming formatter named `progress` is
+installed, non-verbose bounded raw downloads report transferred bytes on
+stderr. Known totals use the final response's `Content-Length`; chunked or
+unknown-length responses report bytes without a percentage. Redirected stderr,
+verbose requests, and installations without the formatter remain silent.
+
 Control exactly what stdout contains with `--rsh-print`:
 
 ```bash

--- a/site/content/en/docs/plugins/command-plugins.md
+++ b/site/content/en/docs/plugins/command-plugins.md
@@ -101,8 +101,8 @@ Older Restish versions ignore the additional fields and continue printing
 
 `current` and `total` are optional, but must be supplied together. Use the same
 `id` for updates to one task, and send a terminal `state` such as `success` or
-`failed` on its final update. Progress remains on stderr and never changes the
-command's primary stdout result.
+`failed` on its final update. Set `unit` when the count is not steps. Progress
+remains on stderr and never changes the command's primary stdout result.
 
 ## Lifecycle
 

--- a/site/content/en/docs/plugins/command-plugins.md
+++ b/site/content/en/docs/plugins/command-plugins.md
@@ -75,6 +75,35 @@ Non-Go plugins can send the same message families directly:
 }
 ```
 
+## Structured Progress
+
+Use `Progress` for a plain status line. Use `ProgressUpdate` when a command can
+report a stable identity, state, and optional step count:
+
+```go
+current, total := int64(2), int64(4)
+err := c.ProgressUpdate(plugin.ProgressMsg{
+  Text:    "Running step 2 of 4: fetch owner",
+  ID:      "workflow",
+  Label:   "Run workflow",
+  State:   "running",
+  Current: &current,
+  Total:   &total,
+  Message: "fetch owner",
+})
+```
+
+`Text` is always the fallback. Restish prints it on stderr when no streaming
+formatter named `progress` is installed. When that formatter is available,
+Restish keeps one formatter session open and sends it the structured records.
+Older Restish versions ignore the additional fields and continue printing
+`Text`.
+
+`current` and `total` are optional, but must be supplied together. Use the same
+`id` for updates to one task, and send a terminal `state` such as `success` or
+`failed` on its final update. Progress remains on stderr and never changes the
+command's primary stdout result.
+
 ## Lifecycle
 
 1. The plugin declares commands during startup discovery.

--- a/site/content/en/docs/reference/plugin-messages.md
+++ b/site/content/en/docs/reference/plugin-messages.md
@@ -630,7 +630,7 @@ CBOR: `text`; type: `string`; required: yes
 
 ### `ProgressMsg`
 
-ProgressMsg prints an informational progress line on the host stderr.
+ProgressMsg reports command progress on the host stderr. Text is the plain fallback when no structured progress formatter is available.
 
 **`Type`**
 
@@ -639,6 +639,30 @@ CBOR: `type`; type: `string`; required: yes
 **`Text`**
 
 CBOR: `text`; type: `string`; required: yes
+
+**`ID`**
+
+CBOR: `id`; type: `string`; required: no
+
+**`Label`**
+
+CBOR: `label`; type: `string`; required: no
+
+**`State`**
+
+CBOR: `state`; type: `string`; required: no
+
+**`Current`**
+
+CBOR: `current`; type: `*int64`; required: no
+
+**`Total`**
+
+CBOR: `total`; type: `*int64`; required: no
+
+**`Message`**
+
+CBOR: `message`; type: `string`; required: no
 
 
 ### `SpinnerMsg`

--- a/site/content/en/docs/reference/plugin-messages.md
+++ b/site/content/en/docs/reference/plugin-messages.md
@@ -660,6 +660,10 @@ CBOR: `current`; type: `*int64`; required: no
 
 CBOR: `total`; type: `*int64`; required: no
 
+**`Unit`**
+
+CBOR: `unit`; type: `string`; required: no
+
 **`Message`**
 
 CBOR: `message`; type: `string`; required: no


### PR DESCRIPTION
## Summary

- reports throttled transferred-byte progress for bounded raw downloads when stderr is a terminal and a `progress` formatter is installed
- preserves buffered size limits, decompression, retries, redirects, stdout purity, and silent fallback without the formatter
- shares timeout, cancellation, and subprocess cleanup with command progress

Closes #432

This is stacked on #431. The download-only commit is `c36cf84`.

## Behavior

I served exactly 1 MiB as `bytes(range(256)) * 4096`, with `Content-Length: 1048576`, in 64 KiB chunks every 30 ms. I installed the same `restish-progress` binary for both CLI builds, then ran each command with stderr attached to a pseudo-terminal and stdout redirected:

```console
$ restish plugin install ./restish-progress --yes
$ script -qec 'restish-before get http://127.0.0.1:18768/file.bin > before.bin' /dev/null
$ script -qec 'restish-after get http://127.0.0.1:18768/file.bin > after.bin' /dev/null
```

The base build emitted no stderr status. The patched build redrew one terminal line with throttled updates and ended with:

```text
31% ███████░░░░░░░░░░░░░░░░░  Download  327680/1048576 bytes  running
51% ████████████░░░░░░░░░░░░  Download  538944/1048576 bytes  running
81% ███████████████████░░░░░  Download  851968/1048576 bytes  running
100% ████████████████████████  Download  1048576/1048576 bytes  success
```

The downloaded bytes stayed identical:

```console
$ sha256sum before.bin after.bin
fbbab289f7f94b25736c58be46a994c441fd02552cc6022352e3d86d2fab7c83  before.bin
fbbab289f7f94b25736c58be46a994c441fd02552cc6022352e3d86d2fab7c83  after.bin
$ wc -c before.bin after.bin
1048576 before.bin
1048576 after.bin
2097152 total
```

The local CI-parity run passed unit and integration tests, the race detector, vet, all five binary builds, generated-doc validation, docs links and examples, social image generation, and the minified Hugo build.

---

> [!NOTE]
> AI assistance: documentation, test scaffolding, PR description.
